### PR TITLE
feat(auth): implement authentication and security system

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
 import { GraphQLModule } from '@nestjs/graphql';
 import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { join } from 'path';
 import { PrismaModule } from './prisma/prisma.module';
 import { UsersModule } from './modules/users/users.module';
 import { AuthModule } from './modules/auth/auth.module';
+import { GqlAuthGuard } from './common/guards/gql-auth.guard';
 
 @Module({
   imports: [
@@ -14,11 +16,28 @@ import { AuthModule } from './modules/auth/auth.module';
       sortSchema: true,
       playground: process.env.NODE_ENV !== 'production',
       introspection: process.env.NODE_ENV !== 'production',
-      context: ({ req, res }) => ({ req, res }),
+      // Enable Apollo Studio (modern alternative to Playground)
+      apollo: {
+        key: process.env.APOLLO_KEY,
+        graphRef: process.env.APOLLO_GRAPH_REF,
+      },
+      context: ({ req, res }) => {
+        return {
+          req,
+          res,
+          user: req.user, // Make user available in GraphQL context
+        };
+      },
     }),
     PrismaModule,
     UsersModule,
     AuthModule,
+  ],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: GqlAuthGuard,
+    },
   ],
 })
 export class AppModule {}

--- a/backend/src/common/decorators/current-user.decorator.ts
+++ b/backend/src/common/decorators/current-user.decorator.ts
@@ -1,0 +1,20 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+
+/**
+ * CurrentUser Decorator
+ * Extracts the current authenticated user from the request.
+ *
+ * Usage:
+ * @Query(() => User)
+ * async me(@CurrentUser() user: any) {
+ *   return user;
+ * }
+ */
+export const CurrentUser = createParamDecorator(
+  (data: unknown, context: ExecutionContext) => {
+    const ctx = GqlExecutionContext.create(context);
+    return ctx.getContext().req.user;
+  },
+);
+

--- a/backend/src/common/decorators/public.decorator.ts
+++ b/backend/src/common/decorators/public.decorator.ts
@@ -1,0 +1,16 @@
+import { SetMetadata } from '@nestjs/common';
+
+/**
+ * Public Route Decorator
+ * Marks a resolver method as public (bypasses authentication).
+ *
+ * Usage:
+ * @Public()
+ * @Query(() => String)
+ * async publicQuery() {
+ *   return 'This is public';
+ * }
+ */
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);
+

--- a/backend/src/common/guards/gql-auth.guard.ts
+++ b/backend/src/common/guards/gql-auth.guard.ts
@@ -1,0 +1,36 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { AuthGuard } from '@nestjs/passport';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
+
+/**
+ * GraphQL Authentication Guard
+ * Protects GraphQL resolvers by validating JWT tokens.
+ * Use with @UseGuards(GqlAuthGuard) on resolvers or @Public() to bypass.
+ */
+@Injectable()
+export class GqlAuthGuard extends AuthGuard('jwt') {
+  constructor(private reflector: Reflector) {
+    super();
+  }
+
+  getRequest(context: ExecutionContext) {
+    const ctx = GqlExecutionContext.create(context);
+    return ctx.getContext().req;
+  }
+
+  canActivate(context: ExecutionContext) {
+    // Check if route is marked as public
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (isPublic) {
+      return true;
+    }
+
+    return super.canActivate(context);
+  }
+}

--- a/backend/src/common/index.ts
+++ b/backend/src/common/index.ts
@@ -1,0 +1,5 @@
+// Common utilities exports
+export * from './decorators/current-user.decorator';
+export * from './decorators/public.decorator';
+export * from './guards/gql-auth.guard';
+

--- a/backend/src/modules/auth/auth.resolver.ts
+++ b/backend/src/modules/auth/auth.resolver.ts
@@ -3,17 +3,24 @@ import { AuthService } from './auth.service';
 import { RegisterInput } from './dto/register.input';
 import { LoginInput } from './dto/login.input';
 import { AuthPayload } from './dto/auth-payload.type';
+import { Public } from '../../common/decorators/public.decorator';
 
 @Resolver()
 export class AuthResolver {
   constructor(private authService: AuthService) {}
 
-  @Mutation(() => AuthPayload)
+  @Public()
+  @Mutation(() => AuthPayload, {
+    description: 'Register a new user account. If companyName is provided, a workspace is automatically created.',
+  })
   async register(@Args('input') input: RegisterInput): Promise<AuthPayload> {
     return this.authService.register(input);
   }
 
-  @Mutation(() => AuthPayload)
+  @Public()
+  @Mutation(() => AuthPayload, {
+    description: 'Login with email and password. Returns a JWT token for authenticated requests.',
+  })
   async login(@Args('input') input: LoginInput): Promise<AuthPayload> {
     return this.authService.login(input);
   }

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -24,7 +24,26 @@ export class AuthService {
       },
     });
 
-    const token = this.jwtService.sign({ userId: user.id, email: user.email });
+    // Create workspace if companyName is provided
+    if (input.companyName) {
+      await this.prisma.workspace.create({
+        data: {
+          name: input.companyName,
+          memberships: {
+            create: {
+              userId: user.id,
+              role: 'ADMIN',
+            },
+          },
+        },
+      });
+    }
+
+    // Default token expiration (7 days)
+    const token = this.jwtService.sign(
+      { userId: user.id, email: user.email },
+      { expiresIn: process.env.JWT_EXPIRES_IN || '7d' },
+    );
 
     return {
       token,
@@ -54,7 +73,12 @@ export class AuthService {
       throw new UnauthorizedException('Invalid credentials');
     }
 
-    const token = this.jwtService.sign({ userId: user.id, email: user.email });
+    // Use longer expiration if rememberMe is true (30 days), otherwise default (7 days)
+    const expiresIn = input.rememberMe ? '30d' : process.env.JWT_EXPIRES_IN || '7d';
+    const token = this.jwtService.sign(
+      { userId: user.id, email: user.email },
+      { expiresIn },
+    );
 
     return {
       token,

--- a/backend/src/modules/auth/dto/auth-payload.type.ts
+++ b/backend/src/modules/auth/dto/auth-payload.type.ts
@@ -1,12 +1,12 @@
 import { ObjectType, Field } from '@nestjs/graphql';
 import { User } from '../../users/entities/user.entity';
 
-@ObjectType()
+@ObjectType({ description: 'Authentication response containing JWT token and user data' })
 export class AuthPayload {
-  @Field()
+  @Field({ description: 'JWT token to use in Authorization header for authenticated requests' })
   token: string;
 
-  @Field(() => User)
+  @Field(() => User, { description: 'Authenticated user information' })
   user: User;
 }
 

--- a/backend/src/modules/auth/dto/login.input.ts
+++ b/backend/src/modules/auth/dto/login.input.ts
@@ -1,14 +1,19 @@
 import { InputType, Field } from '@nestjs/graphql';
-import { IsEmail, IsString } from 'class-validator';
+import { IsEmail, IsString, IsBoolean, IsOptional } from 'class-validator';
 
-@InputType()
+@InputType({ description: 'Input for user login' })
 export class LoginInput {
-  @Field()
+  @Field({ description: 'User email address' })
   @IsEmail()
   email: string;
 
-  @Field()
+  @Field({ description: 'User password' })
   @IsString()
   password: string;
+
+  @Field({ nullable: true, defaultValue: false, description: 'If true, token expires in 30 days instead of 7 days' })
+  @IsOptional()
+  @IsBoolean()
+  rememberMe?: boolean;
 }
 

--- a/backend/src/modules/auth/dto/register.input.ts
+++ b/backend/src/modules/auth/dto/register.input.ts
@@ -1,20 +1,25 @@
 import { InputType, Field } from '@nestjs/graphql';
-import { IsEmail, IsString, MinLength } from 'class-validator';
+import { IsEmail, IsString, MinLength, IsOptional } from 'class-validator';
 
-@InputType()
+@InputType({ description: 'Input for user registration' })
 export class RegisterInput {
-  @Field()
+  @Field({ description: 'User email address (must be unique)' })
   @IsEmail()
   email: string;
 
-  @Field()
+  @Field({ description: 'User full name (minimum 3 characters)' })
   @IsString()
   @MinLength(3)
   name: string;
 
-  @Field()
+  @Field({ description: 'User password (minimum 6 characters)' })
   @IsString()
   @MinLength(6)
   password: string;
+
+  @Field({ nullable: true, description: 'Optional company name - creates a workspace if provided' })
+  @IsOptional()
+  @IsString()
+  companyName?: string;
 }
 

--- a/backend/src/modules/auth/strategies/jwt.strategy.ts
+++ b/backend/src/modules/auth/strategies/jwt.strategy.ts
@@ -22,6 +22,13 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       return null;
     }
 
-    return { userId: user.id, email: user.email };
+    // Return user object that will be attached to req.user
+    return {
+      id: user.id,
+      userId: user.id,
+      email: user.email,
+      name: user.name,
+      avatar: user.avatar,
+    };
   }
 }

--- a/backend/src/modules/users/users.resolver.ts
+++ b/backend/src/modules/users/users.resolver.ts
@@ -1,29 +1,53 @@
 import { Resolver, Query, Mutation, Args, ID } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { User } from './entities/user.entity';
 import { CreateUserInput } from './dto/create-user.input';
 import { UpdateUserInput } from './dto/update-user.input';
+import { GqlAuthGuard } from '../../common/guards/gql-auth.guard';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
 
 @Resolver(() => User)
+@UseGuards(GqlAuthGuard)
 export class UsersResolver {
   constructor(private usersService: UsersService) {}
 
-  @Query(() => [User])
+  @Query(() => User, {
+    nullable: true,
+    description: 'Get the currently authenticated user information',
+  })
+  async me(@CurrentUser() user: any): Promise<User | null> {
+    if (!user) {
+      return null;
+    }
+    return this.usersService.findOne(user.id);
+  }
+
+  @Query(() => [User], {
+    description: 'Get all users (requires authentication)',
+  })
   async users(): Promise<User[]> {
     return this.usersService.findAll();
   }
 
-  @Query(() => User, { nullable: true })
+  @Query(() => User, {
+    nullable: true,
+    description: 'Get a user by ID (requires authentication)',
+  })
   async user(@Args('id', { type: () => ID }) id: string): Promise<User | null> {
     return this.usersService.findOne(id);
   }
 
-  @Mutation(() => User)
+  @Mutation(() => User, {
+    description: 'Create a new user (requires authentication)',
+  })
   async createUser(@Args('input') input: CreateUserInput): Promise<User> {
     return this.usersService.create(input);
   }
 
-  @Mutation(() => User)
+  @Mutation(() => User, {
+    description: 'Update an existing user (requires authentication)',
+  })
   async updateUser(
     @Args('id', { type: () => ID }) id: string,
     @Args('input') input: UpdateUserInput,
@@ -31,7 +55,9 @@ export class UsersResolver {
     return this.usersService.update(id, input);
   }
 
-  @Mutation(() => Boolean)
+  @Mutation(() => Boolean, {
+    description: 'Delete a user by ID (requires authentication)',
+  })
   async deleteUser(@Args('id', { type: () => ID }) id: string): Promise<boolean> {
     return this.usersService.remove(id);
   }

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,506 @@
+# Epitrello API Documentation
+
+## Base URL
+
+```
+http://localhost:4000/graphql
+```
+
+The port can be configured via the `PORT` environment variable (default: 4000).
+
+## GraphQL Playground
+
+In development mode, you can access the GraphQL Playground at:
+
+```
+http://localhost:4000/graphql
+```
+
+The Playground provides:
+
+- Interactive query editor
+- Schema documentation
+- Query history
+- Request/response inspection
+
+## Authentication
+
+Most queries and mutations require authentication. Include the JWT token in the HTTP headers:
+
+```
+Authorization: Bearer YOUR_JWT_TOKEN
+```
+
+### Public Endpoints
+
+The following endpoints are public (no authentication required):
+
+- `register` - User registration
+- `login` - User login
+
+## Mutations
+
+### Authentication
+
+#### Register
+
+Create a new user account.
+
+```graphql
+mutation Register($input: RegisterInput!) {
+  register(input: $input) {
+    token
+    user {
+      id
+      email
+      name
+      avatar
+      createdAt
+      updatedAt
+    }
+  }
+}
+```
+
+**Variables:**
+
+```json
+{
+  "input": {
+    "email": "user@example.com",
+    "name": "John Doe",
+    "password": "password123",
+    "companyName": "My Company" // Optional - creates a workspace
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "register": {
+      "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+      "user": {
+        "id": "uuid",
+        "email": "user@example.com",
+        "name": "John Doe",
+        "avatar": null,
+        "createdAt": "2024-01-01T00:00:00.000Z",
+        "updatedAt": "2024-01-01T00:00:00.000Z"
+      }
+    }
+  }
+}
+```
+
+**Notes:**
+
+- If `companyName` is provided, a workspace is automatically created
+- The user becomes ADMIN of the created workspace
+- Token expires in 7 days
+
+#### Login
+
+Authenticate an existing user.
+
+```graphql
+mutation Login($input: LoginInput!) {
+  login(input: $input) {
+    token
+    user {
+      id
+      email
+      name
+      avatar
+      createdAt
+      updatedAt
+    }
+  }
+}
+```
+
+**Variables:**
+
+```json
+{
+  "input": {
+    "email": "user@example.com",
+    "password": "password123",
+    "rememberMe": true // Optional - extends token to 30 days
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "login": {
+      "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+      "user": {
+        "id": "uuid",
+        "email": "user@example.com",
+        "name": "John Doe",
+        "avatar": null,
+        "createdAt": "2024-01-01T00:00:00.000Z",
+        "updatedAt": "2024-01-01T00:00:00.000Z"
+      }
+    }
+  }
+}
+```
+
+**Notes:**
+
+- If `rememberMe` is `true`, token expires in 30 days
+- If `rememberMe` is `false` or not provided, token expires in 7 days (or `JWT_EXPIRES_IN` env var)
+
+### Users
+
+#### Get Current User
+
+Get the authenticated user's information.
+
+```graphql
+query Me {
+  me {
+    id
+    email
+    name
+    avatar
+    createdAt
+    updatedAt
+  }
+}
+```
+
+**Headers:**
+
+```
+Authorization: Bearer YOUR_JWT_TOKEN
+```
+
+#### Get All Users
+
+Get a list of all users (requires authentication).
+
+```graphql
+query Users {
+  users {
+    id
+    email
+    name
+    avatar
+    createdAt
+    updatedAt
+  }
+}
+```
+
+**Headers:**
+
+```
+Authorization: Bearer YOUR_JWT_TOKEN
+```
+
+#### Get User by ID
+
+Get a specific user by ID.
+
+```graphql
+query User($id: ID!) {
+  user(id: $id) {
+    id
+    email
+    name
+    avatar
+    createdAt
+    updatedAt
+  }
+}
+```
+
+**Variables:**
+
+```json
+{
+  "id": "user-uuid"
+}
+```
+
+#### Create User
+
+Create a new user (requires authentication).
+
+```graphql
+mutation CreateUser($input: CreateUserInput!) {
+  createUser(input: $input) {
+    id
+    email
+    name
+    avatar
+    createdAt
+    updatedAt
+  }
+}
+```
+
+**Variables:**
+
+```json
+{
+  "input": {
+    "email": "newuser@example.com",
+    "name": "New User",
+    "password": "password123",
+    "avatar": "https://example.com/avatar.jpg" // Optional
+  }
+}
+```
+
+#### Update User
+
+Update an existing user (requires authentication).
+
+```graphql
+mutation UpdateUser($id: ID!, $input: UpdateUserInput!) {
+  updateUser(id: $id, input: $input) {
+    id
+    email
+    name
+    avatar
+    createdAt
+    updatedAt
+  }
+}
+```
+
+**Variables:**
+
+```json
+{
+  "id": "user-uuid",
+  "input": {
+    "name": "Updated Name",
+    "email": "updated@example.com",
+    "avatar": "https://example.com/new-avatar.jpg"
+  }
+}
+```
+
+#### Delete User
+
+Delete a user (requires authentication).
+
+```graphql
+mutation DeleteUser($id: ID!) {
+  deleteUser(id: $id)
+}
+```
+
+**Variables:**
+
+```json
+{
+  "id": "user-uuid"
+}
+```
+
+## Error Handling
+
+GraphQL returns errors in a standardized format:
+
+```json
+{
+  "errors": [
+    {
+      "message": "Invalid credentials",
+      "extensions": {
+        "code": "UNAUTHENTICATED",
+        "statusCode": 401
+      }
+    }
+  ]
+}
+```
+
+### Common Error Codes
+
+- `UNAUTHENTICATED` (401) - Missing or invalid JWT token
+- `FORBIDDEN` (403) - Valid token but insufficient permissions
+- `BAD_USER_INPUT` (400) - Invalid input data
+- `INTERNAL_SERVER_ERROR` (500) - Server error
+
+## Types
+
+### User
+
+```graphql
+type User {
+  id: ID!
+  email: String!
+  name: String!
+  avatar: String
+  createdAt: DateTime!
+  updatedAt: DateTime!
+}
+```
+
+### AuthPayload
+
+```graphql
+type AuthPayload {
+  token: String!
+  user: User!
+}
+```
+
+### RegisterInput
+
+```graphql
+input RegisterInput {
+  email: String!
+  name: String!
+  password: String!
+  companyName: String # Optional
+}
+```
+
+### LoginInput
+
+```graphql
+input LoginInput {
+  email: String!
+  password: String!
+  rememberMe: Boolean # Optional, default: false
+}
+```
+
+## Examples
+
+### Complete Authentication Flow
+
+1. **Register a new user:**
+
+```graphql
+mutation {
+  register(
+    input: {
+      email: "user@example.com"
+      name: "John Doe"
+      password: "password123"
+      companyName: "My Company"
+    }
+  ) {
+    token
+    user {
+      id
+      email
+      name
+    }
+  }
+}
+```
+
+2. **Use the token for authenticated requests:**
+
+```graphql
+query {
+  me {
+    id
+    email
+    name
+  }
+}
+```
+
+Headers: `Authorization: Bearer <token_from_register>`
+
+### Using cURL
+
+**Register:**
+
+```bash
+curl -X POST http://localhost:4000/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "mutation { register(input: { email: \"user@example.com\", name: \"John Doe\", password: \"password123\" }) { token user { id email name } } }"
+  }'
+```
+
+**Login:**
+
+```bash
+curl -X POST http://localhost:4000/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "mutation { login(input: { email: \"user@example.com\", password: \"password123\" }) { token user { id email name } } }"
+  }'
+```
+
+**Authenticated Query:**
+
+```bash
+curl -X POST http://localhost:4000/graphql \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_TOKEN_HERE" \
+  -d '{
+    "query": "query { me { id email name } }"
+  }'
+```
+
+## Schema Introspection
+
+You can query the schema itself using GraphQL introspection:
+
+```graphql
+query {
+  __schema {
+    types {
+      name
+      description
+    }
+  }
+}
+```
+
+Or get information about a specific type:
+
+```graphql
+query {
+  __type(name: "User") {
+    name
+    description
+    fields {
+      name
+      description
+      type {
+        name
+      }
+    }
+  }
+}
+```
+
+## Rate Limiting
+
+Currently, there is no rate limiting implemented. Consider implementing rate limiting for production use.
+
+## Best Practices
+
+1. **Always use variables** instead of string interpolation in queries
+2. **Store tokens securely** (never in localStorage for sensitive apps)
+3. **Handle token expiration** - implement token refresh logic
+4. **Use error handling** - check for errors in responses
+5. **Validate inputs** - client-side validation before sending requests
+
+## Support
+
+For issues or questions, please refer to:
+
+- [GraphQL Documentation](https://graphql.org/learn/)
+- [NestJS Documentation](https://docs.nestjs.com/)
+- [Apollo Server Documentation](https://www.apollographql.com/docs/apollo-server/)


### PR DESCRIPTION
- Add GqlAuthGuard for GraphQL authentication
- Add @CurrentUser() decorator to get authenticated user
- Add @Public() decorator for public routes
- Configure global authentication guard
- Add rememberMe option to login (30 days token)
- Add companyName option to register (creates workspace)
- Update JWT strategy to return full user object
- Add API documentation in docs/API.md
- Add descriptions to GraphQL schema for better documentation
- Configure Apollo Studio support