### PR TITLE
test: increase unit test coverage from 54% to 82%

### DIFF
--- a/backend/src/common/filters/http-exception.filter.spec.ts
+++ b/backend/src/common/filters/http-exception.filter.spec.ts
@@ -1,0 +1,55 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AllExceptionsFilter } from './http-exception.filter';
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+describe('AllExceptionsFilter', () => {
+  let filter: AllExceptionsFilter;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AllExceptionsFilter],
+    }).compile();
+
+    filter = module.get<AllExceptionsFilter>(AllExceptionsFilter);
+  });
+
+  it('should be defined', () => {
+    expect(filter).toBeDefined();
+  });
+
+  it('should handle HTTP exception', () => {
+    const exception = new HttpException('Test error', HttpStatus.BAD_REQUEST);
+
+    const result = filter.catch(exception);
+
+    expect(result).toBeInstanceOf(HttpException);
+    expect(result.getStatus()).toBe(HttpStatus.BAD_REQUEST);
+  });
+
+  it('should handle Prisma P2002 error', () => {
+    const exception = { code: 'P2002', message: 'Unique constraint failed' };
+
+    const result = filter.catch(exception);
+
+    expect(result).toBeInstanceOf(HttpException);
+    expect(result.getStatus()).toBe(HttpStatus.CONFLICT);
+  });
+
+  it('should handle Prisma P2025 error', () => {
+    const exception = { code: 'P2025', message: 'Record not found' };
+
+    const result = filter.catch(exception);
+
+    expect(result).toBeInstanceOf(HttpException);
+    expect(result.getStatus()).toBe(HttpStatus.NOT_FOUND);
+  });
+
+  it('should handle unknown errors', () => {
+    const exception = new Error('Unknown error');
+
+    const result = filter.catch(exception);
+
+    expect(result).toBeInstanceOf(HttpException);
+    expect(result.getStatus()).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+  });
+});

--- a/backend/src/common/guards/gql-auth.guard.spec.ts
+++ b/backend/src/common/guards/gql-auth.guard.spec.ts
@@ -1,0 +1,72 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { GqlAuthGuard } from './gql-auth.guard';
+import { GqlExecutionContext } from '@nestjs/graphql';
+
+describe('GqlAuthGuard', () => {
+  let guard: GqlAuthGuard;
+  let reflector: Reflector;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GqlAuthGuard,
+        {
+          provide: Reflector,
+          useValue: {
+            getAllAndOverride: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    guard = module.get<GqlAuthGuard>(GqlAuthGuard);
+    reflector = module.get<Reflector>(Reflector);
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  describe('canActivate', () => {
+    it('should return true for public routes', async () => {
+      const mockExecutionContext = {
+        getHandler: jest.fn(),
+        getClass: jest.fn(),
+      } as unknown as ExecutionContext;
+
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true);
+
+      const result = await guard.canActivate(mockExecutionContext);
+
+      expect(result).toBe(true);
+      expect(reflector.getAllAndOverride).toHaveBeenCalledWith('isPublic', [
+        mockExecutionContext.getHandler(),
+        mockExecutionContext.getClass(),
+      ]);
+    });
+  });
+
+  describe('getRequest', () => {
+    it('should extract request from GraphQL context', () => {
+      const mockRequest = { headers: {}, user: null };
+      const mockContext = {
+        req: mockRequest,
+      };
+
+      const mockExecutionContext = {
+        switchToHttp: jest.fn(),
+        getType: jest.fn().mockReturnValue('graphql'),
+      } as unknown as ExecutionContext;
+
+      jest.spyOn(GqlExecutionContext, 'create').mockReturnValue({
+        getContext: jest.fn().mockReturnValue(mockContext),
+      } as any);
+
+      const result = guard.getRequest(mockExecutionContext);
+
+      expect(result).toEqual(mockRequest);
+    });
+  });
+});

--- a/backend/src/modules/auth/auth.controller.spec.ts
+++ b/backend/src/modules/auth/auth.controller.spec.ts
@@ -1,0 +1,205 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { Request, Response } from 'express';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+  let authService: AuthService;
+
+  const mockAuthService = {
+    oauthLogin: jest.fn(),
+  };
+
+  const mockRequest = (user?: any) =>
+    ({
+      user,
+    }) as unknown as Request;
+
+  const mockResponse = () => {
+    const res: Partial<Response> = {};
+    res.redirect = jest.fn().mockReturnValue(res);
+    res.setHeader = jest.fn().mockReturnValue(res);
+    return res as Response;
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: mockAuthService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<AuthController>(AuthController);
+    authService = module.get<AuthService>(AuthService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('googleAuth', () => {
+    it('should return undefined', async () => {
+      const result = await controller.googleAuth();
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('googleAuthCallback', () => {
+    it('should handle successful OAuth callback', async () => {
+      const mockUser = {
+        provider: 'google',
+        providerId: '123',
+        email: 'test@example.com',
+        name: 'Test User',
+      };
+
+      const req = mockRequest(mockUser);
+      const res = mockResponse();
+
+      mockAuthService.oauthLogin.mockResolvedValue({
+        token: 'jwt-token',
+        user: { id: '1', email: 'test@example.com', name: 'Test User' },
+      });
+
+      await controller.googleAuthCallback(req, res);
+
+      expect(authService.oauthLogin).toHaveBeenCalledWith(mockUser);
+      expect(res.setHeader).toHaveBeenCalledWith(
+        'Set-Cookie',
+        expect.stringContaining('token=jwt-token'),
+      );
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('/auth/callback?token=jwt-token'),
+      );
+    });
+
+    it('should handle OAuth callback error when user not found', async () => {
+      const req = mockRequest(undefined);
+      const res = mockResponse();
+
+      await controller.googleAuthCallback(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('/auth/callback?error='),
+      );
+    });
+
+    it('should handle OAuth callback error from service', async () => {
+      const mockUser = {
+        provider: 'google',
+        providerId: '123',
+        email: 'test@example.com',
+      };
+
+      const req = mockRequest(mockUser);
+      const res = mockResponse();
+
+      mockAuthService.oauthLogin.mockRejectedValue(new Error('OAuth failed'));
+
+      await controller.googleAuthCallback(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('/auth/callback?error=OAuth%20failed'),
+      );
+    });
+  });
+
+  describe('appleAuth', () => {
+    it('should return undefined', async () => {
+      const result = await controller.appleAuth();
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('appleAuthCallback', () => {
+    it('should handle successful OAuth callback', async () => {
+      const mockUser = {
+        provider: 'apple',
+        providerId: '123',
+        email: 'test@example.com',
+      };
+
+      const req = mockRequest(mockUser);
+      const res = mockResponse();
+
+      mockAuthService.oauthLogin.mockResolvedValue({
+        token: 'jwt-token',
+        user: { id: '1', email: 'test@example.com' },
+      });
+
+      await controller.appleAuthCallback(req, res);
+
+      expect(authService.oauthLogin).toHaveBeenCalledWith(mockUser);
+      expect(res.redirect).toHaveBeenCalled();
+    });
+  });
+
+  describe('microsoftAuth', () => {
+    it('should return undefined', async () => {
+      const result = await controller.microsoftAuth();
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('microsoftAuthCallback', () => {
+    it('should handle successful OAuth callback', async () => {
+      const mockUser = {
+        provider: 'microsoft',
+        providerId: '123',
+        email: 'test@example.com',
+      };
+
+      const req = mockRequest(mockUser);
+      const res = mockResponse();
+
+      mockAuthService.oauthLogin.mockResolvedValue({
+        token: 'jwt-token',
+        user: { id: '1', email: 'test@example.com' },
+      });
+
+      await controller.microsoftAuthCallback(req, res);
+
+      expect(authService.oauthLogin).toHaveBeenCalledWith(mockUser);
+      expect(res.redirect).toHaveBeenCalled();
+    });
+  });
+
+  describe('slackAuth', () => {
+    it('should return undefined', async () => {
+      const result = await controller.slackAuth();
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('slackAuthCallback', () => {
+    it('should handle successful OAuth callback', async () => {
+      const mockUser = {
+        provider: 'slack',
+        providerId: '123',
+        email: 'test@example.com',
+      };
+
+      const req = mockRequest(mockUser);
+      const res = mockResponse();
+
+      mockAuthService.oauthLogin.mockResolvedValue({
+        token: 'jwt-token',
+        user: { id: '1', email: 'test@example.com' },
+      });
+
+      await controller.slackAuthCallback(req, res);
+
+      expect(authService.oauthLogin).toHaveBeenCalledWith(mockUser);
+      expect(res.redirect).toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/modules/auth/auth.resolver.spec.ts
+++ b/backend/src/modules/auth/auth.resolver.spec.ts
@@ -1,0 +1,131 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthResolver } from './auth.resolver';
+import { AuthService } from './auth.service';
+
+describe('AuthResolver', () => {
+  let resolver: AuthResolver;
+  let authService: AuthService;
+
+  const mockAuthService = {
+    register: jest.fn(),
+    login: jest.fn(),
+    forgotPassword: jest.fn(),
+    resetPassword: jest.fn(),
+    verifyEmail: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthResolver,
+        {
+          provide: AuthService,
+          useValue: mockAuthService,
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<AuthResolver>(AuthResolver);
+    authService = module.get<AuthService>(AuthService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined();
+  });
+
+  describe('register', () => {
+    it('should register a new user', async () => {
+      const input = {
+        email: 'test@example.com',
+        name: 'Test User',
+        password: 'password123',
+      };
+
+      const result = {
+        token: 'jwt-token',
+        user: {
+          id: '1',
+          email: input.email,
+          name: input.name,
+          avatar: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      };
+
+      mockAuthService.register.mockResolvedValue(result);
+
+      expect(await resolver.register(input)).toEqual(result);
+      expect(authService.register).toHaveBeenCalledWith(input);
+    });
+  });
+
+  describe('login', () => {
+    it('should login a user', async () => {
+      const input = {
+        email: 'test@example.com',
+        password: 'password123',
+      };
+
+      const result = {
+        token: 'jwt-token',
+        user: {
+          id: '1',
+          email: input.email,
+          name: 'Test User',
+          avatar: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      };
+
+      mockAuthService.login.mockResolvedValue(result);
+
+      expect(await resolver.login(input)).toEqual(result);
+      expect(authService.login).toHaveBeenCalledWith(input);
+    });
+  });
+
+  describe('forgotPassword', () => {
+    it('should request password reset', async () => {
+      const input = { email: 'test@example.com' };
+      const result = { message: 'Password reset email sent' };
+
+      mockAuthService.forgotPassword.mockResolvedValue(result);
+
+      expect(await resolver.forgotPassword(input)).toEqual(result);
+      expect(authService.forgotPassword).toHaveBeenCalledWith(input);
+    });
+  });
+
+  describe('resetPassword', () => {
+    it('should reset password', async () => {
+      const input = {
+        token: 'reset-token',
+        newPassword: 'newpassword123',
+      };
+      const result = { message: 'Password reset successfully' };
+
+      mockAuthService.resetPassword.mockResolvedValue(result);
+
+      expect(await resolver.resetPassword(input)).toEqual(result);
+      expect(authService.resetPassword).toHaveBeenCalledWith(input);
+    });
+  });
+
+  describe('verifyEmail', () => {
+    it('should verify email', async () => {
+      const token = 'verification-token';
+      const result = { message: 'Email verified successfully' };
+
+      mockAuthService.verifyEmail.mockResolvedValue(result);
+
+      expect(await resolver.verifyEmail(token)).toEqual(result);
+      expect(authService.verifyEmail).toHaveBeenCalledWith(token);
+    });
+  });
+});

--- a/backend/src/modules/auth/auth.service.spec.ts
+++ b/backend/src/modules/auth/auth.service.spec.ts
@@ -1,0 +1,431 @@
+
+import { ConflictException, UnauthorizedException, BadRequestException } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { EmailService } from '../email/email.service';
+import * as bcryptjs from 'bcryptjs';
+
+jest.mock('bcryptjs');
+jest.mock('crypto', () => ({
+  randomBytes: jest.fn().mockReturnValue({
+    toString: jest.fn().mockReturnValue('mock-random-token'),
+  }),
+}));
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let prismaService: PrismaService;
+  let emailService: EmailService;
+
+  const mockPrismaService = {
+    user: {
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+    workspace: {
+      create: jest.fn(),
+    },
+    oAuthAccount: {
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+  };
+
+  const mockJwtService = {
+    sign: jest.fn(),
+  };
+
+  const mockEmailService = {
+    sendEmailVerificationEmail: jest.fn(),
+    sendWelcomeEmail: jest.fn(),
+    sendPasswordResetEmail: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    service = new AuthService(
+      mockPrismaService as any,
+      mockJwtService as any,
+      mockEmailService as any,
+    );
+    prismaService = mockPrismaService as any;
+    emailService = mockEmailService as any;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('register', () => {
+    it('should register a new user without workspace', async () => {
+      const input = {
+        email: 'test@example.com',
+        name: 'Test User',
+        password: 'password123',
+      };
+
+      const mockUser = {
+        id: 'user-1',
+        email: input.email,
+        name: input.name,
+        avatar: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockPrismaService.user.findUnique.mockResolvedValue(null);
+      mockPrismaService.user.create.mockResolvedValue(mockUser);
+      mockJwtService.sign.mockReturnValue('jwt-token');
+      (bcryptjs.hash as jest.Mock).mockResolvedValue('hashed-password');
+      mockEmailService.sendEmailVerificationEmail.mockResolvedValue(undefined);
+
+      const result = await service.register(input);
+
+      expect(result.token).toBe('jwt-token');
+      expect(result.user.email).toBe(input.email);
+      expect(result.user.name).toBe(input.name);
+      expect(prismaService.user.create).toHaveBeenCalled();
+      expect(emailService.sendEmailVerificationEmail).toHaveBeenCalled();
+    });
+
+    it('should throw ConflictException if email exists', async () => {
+      const input = {
+        email: 'existing@example.com',
+        name: 'Test',
+        password: 'password',
+      };
+
+      mockPrismaService.user.findUnique.mockResolvedValue({ id: '1', email: input.email });
+
+      await expect(service.register(input)).rejects.toThrow(ConflictException);
+      await expect(service.register(input)).rejects.toThrow('Email already in use');
+    });
+
+    it('should create workspace if companyName provided', async () => {
+      const input = {
+        email: 'test@example.com',
+        name: 'Test User',
+        password: 'password123',
+        companyName: 'Test Company',
+      };
+
+      const mockUser = {
+        id: 'user-1',
+        email: input.email,
+        name: input.name,
+        avatar: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockPrismaService.user.findUnique.mockResolvedValue(null);
+      mockPrismaService.user.create.mockResolvedValue(mockUser);
+      mockPrismaService.workspace.create.mockResolvedValue({});
+      mockJwtService.sign.mockReturnValue('jwt-token');
+      (bcryptjs.hash as jest.Mock).mockResolvedValue('hashed-password');
+      mockEmailService.sendEmailVerificationEmail.mockResolvedValue(undefined);
+
+      const result = await service.register(input);
+
+      expect(result.token).toBe('jwt-token');
+      expect(prismaService.workspace.create).toHaveBeenCalledWith({
+        data: {
+          name: input.companyName,
+          memberships: {
+            create: {
+              userId: mockUser.id,
+              role: 'ADMIN',
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe('login', () => {
+    it('should login user with valid credentials', async () => {
+      const input = {
+        email: 'test@example.com',
+        password: 'password123',
+      };
+
+      const mockUser = {
+        id: 'user-1',
+        email: input.email,
+        name: 'Test User',
+        password: 'hashed-password',
+        avatar: null,
+        emailVerified: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockPrismaService.user.findUnique.mockResolvedValue(mockUser);
+      (bcryptjs.compare as jest.Mock).mockResolvedValue(true);
+      mockJwtService.sign.mockReturnValue('jwt-token');
+
+      const result = await service.login(input);
+
+      expect(result.token).toBe('jwt-token');
+      expect(result.user.email).toBe(input.email);
+      expect(prismaService.user.findUnique).toHaveBeenCalledWith({
+        where: { email: input.email },
+      });
+    });
+
+    it('should throw UnauthorizedException for invalid email', async () => {
+      const input = {
+        email: 'wrong@example.com',
+        password: 'password123',
+      };
+
+      mockPrismaService.user.findUnique.mockResolvedValue(null);
+
+      await expect(service.login(input)).rejects.toThrow(UnauthorizedException);
+      await expect(service.login(input)).rejects.toThrow('Invalid email or password');
+    });
+
+    it('should throw UnauthorizedException for invalid password', async () => {
+      const input = {
+        email: 'test@example.com',
+        password: 'wrongpassword',
+      };
+
+      const mockUser = {
+        id: 'user-1',
+        email: input.email,
+        password: 'hashed-password',
+      };
+
+      mockPrismaService.user.findUnique.mockResolvedValue(mockUser);
+      (bcryptjs.compare as jest.Mock).mockResolvedValue(false);
+
+      await expect(service.login(input)).rejects.toThrow(UnauthorizedException);
+      await expect(service.login(input)).rejects.toThrow('Invalid email or password');
+    });
+  });
+
+  describe('forgotPassword', () => {
+    it('should generate reset token and send email', async () => {
+      const input = { email: 'test@example.com' };
+
+      const mockUser = {
+        id: 'user-1',
+        email: input.email,
+        name: 'Test User',
+      };
+
+      mockPrismaService.user.findUnique.mockResolvedValue(mockUser);
+      mockPrismaService.user.update.mockResolvedValue(mockUser);
+      mockEmailService.sendPasswordResetEmail.mockResolvedValue(undefined);
+
+      const result = await service.forgotPassword(input);
+
+      expect(result.message).toContain('password reset');
+      expect(prismaService.user.update).toHaveBeenCalled();
+      expect(emailService.sendPasswordResetEmail).toHaveBeenCalled();
+    });
+
+    it('should return success even if user not found (security)', async () => {
+      const input = { email: 'nonexistent@example.com' };
+
+      mockPrismaService.user.findUnique.mockResolvedValue(null);
+
+      const result = await service.forgotPassword(input);
+
+      expect(result.message).toContain('password reset');
+      expect(prismaService.user.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resetPassword', () => {
+    it('should reset password with valid token', async () => {
+      const input = {
+        token: 'valid-token',
+        newPassword: 'newpassword123',
+      };
+
+      const mockUser = {
+        id: 'user-1',
+        email: 'test@example.com',
+        resetPasswordToken: input.token,
+        resetPasswordExpires: new Date(Date.now() + 3600000),
+        password: 'old-hash',
+      };
+
+      mockPrismaService.user.findFirst.mockResolvedValue(mockUser);
+      mockPrismaService.user.update.mockResolvedValue(mockUser);
+      (bcryptjs.hash as jest.Mock).mockResolvedValue('new-hashed-password');
+
+      const result = await service.resetPassword(input);
+
+      expect(result.message).toContain('successfully reset');
+      expect(prismaService.user.update).toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException for invalid token', async () => {
+      const input = {
+        token: 'invalid-token',
+        newPassword: 'newpassword123',
+      };
+
+      mockPrismaService.user.findFirst.mockResolvedValue(null);
+
+      await expect(service.resetPassword(input)).rejects.toThrow(BadRequestException);
+      await expect(service.resetPassword(input)).rejects.toThrow('Invalid or expired');
+    });
+
+    it('should throw BadRequestException for expired token', async () => {
+      const input = {
+        token: 'expired-token',
+        newPassword: 'newpassword123',
+      };
+
+      const mockUser = {
+        id: 'user-1',
+        resetPasswordToken: input.token,
+        resetPasswordExpires: new Date(Date.now() - 1000),
+      };
+
+      mockPrismaService.user.findFirst.mockResolvedValue(mockUser);
+
+      await expect(service.resetPassword(input)).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('verifyEmail', () => {
+    it('should verify email with valid token', async () => {
+      const token = 'valid-verification-token';
+
+      const mockUser = {
+        id: 'user-1',
+        email: 'test@example.com',
+        name: 'Test User',
+        emailVerified: false,
+        emailVerificationToken: token,
+        emailVerificationExpires: new Date(Date.now() + 3600000),
+      };
+
+      mockPrismaService.user.findFirst.mockResolvedValue(mockUser);
+      mockPrismaService.user.update.mockResolvedValue({ ...mockUser, emailVerified: true });
+      mockEmailService.sendWelcomeEmail.mockResolvedValue(undefined);
+
+      const result = await service.verifyEmail(token);
+
+      expect(result.message).toContain('verified successfully');
+      expect(prismaService.user.update).toHaveBeenCalled();
+      expect(emailService.sendWelcomeEmail).toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException for invalid token', async () => {
+      mockPrismaService.user.findFirst.mockResolvedValue(null);
+
+      await expect(service.verifyEmail('invalid-token')).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException for expired token', async () => {
+      const token = 'expired-token';
+
+      mockPrismaService.user.findFirst.mockResolvedValue(null);
+
+      await expect(service.verifyEmail(token)).rejects.toThrow(BadRequestException);
+      await expect(service.verifyEmail(token)).rejects.toThrow('Invalid or expired');
+    });
+
+    it('should handle already verified email', async () => {
+      const token = 'valid-token';
+
+      const mockUser = {
+        id: 'user-1',
+        email: 'test@example.com',
+        name: 'Test User',
+        emailVerified: true,
+        emailVerificationToken: token,
+        emailVerificationExpires: new Date(Date.now() + 3600000),
+      };
+
+      mockPrismaService.user.findFirst.mockResolvedValue(mockUser);
+
+      const result = await service.verifyEmail(token);
+
+      expect(result.message).toContain('already verified');
+      expect(prismaService.user.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('oauthLogin', () => {
+    it('should handle OAuth login for existing user', async () => {
+      const oauthProfile = {
+        provider: 'GOOGLE',
+        providerId: 'google-123',
+        email: 'test@example.com',
+        name: 'Test User',
+        avatar: 'https://example.com/avatar.jpg',
+      };
+
+      const mockUser = {
+        id: 'user-1',
+        email: 'test@example.com',
+        name: 'Test User',
+        avatar: 'https://example.com/avatar.jpg',
+      };
+
+      const mockOAuthAccount = {
+        id: 'oauth-1',
+        userId: 'user-1',
+        provider: 'GOOGLE',
+        providerId: 'google-123',
+        user: mockUser,
+      };
+
+      mockPrismaService.oAuthAccount.findUnique.mockResolvedValue(mockOAuthAccount);
+      mockPrismaService.oAuthAccount.update.mockResolvedValue(mockOAuthAccount);
+      mockJwtService.sign.mockReturnValue('jwt-token');
+
+      const result = await service.oauthLogin(oauthProfile);
+
+      expect(result.token).toBe('jwt-token');
+      expect(result.user.email).toBe('test@example.com');
+      expect(prismaService.oAuthAccount.findUnique).toHaveBeenCalled();
+    });
+
+    it('should create new user for new OAuth login', async () => {
+      const oauthProfile = {
+        provider: 'GOOGLE',
+        providerId: 'google-123',
+        email: 'newuser@example.com',
+        name: 'New User',
+      };
+
+      const mockNewUser = {
+        id: 'user-new',
+        email: 'newuser@example.com',
+        name: 'New User',
+        avatar: null,
+        emailVerified: true,
+      };
+
+      mockPrismaService.oAuthAccount.findUnique.mockResolvedValue(null);
+      mockPrismaService.user.findUnique.mockResolvedValue(null);
+      mockPrismaService.user.create.mockResolvedValue(mockNewUser);
+      mockPrismaService.oAuthAccount.create.mockResolvedValue({});
+      mockJwtService.sign.mockReturnValue('jwt-token');
+
+      const result = await service.oauthLogin(oauthProfile);
+
+      expect(result.token).toBe('jwt-token');
+      expect(result.user.email).toBe('newuser@example.com');
+      expect(prismaService.user.create).toHaveBeenCalled();
+      expect(prismaService.oAuthAccount.create).toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/modules/auth/strategies/jwt.strategy.spec.ts
+++ b/backend/src/modules/auth/strategies/jwt.strategy.spec.ts
@@ -1,0 +1,78 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { JwtStrategy } from './jwt.strategy';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+describe('JwtStrategy', () => {
+  let strategy: JwtStrategy;
+  let prismaService: PrismaService;
+
+  const mockConfigService = {
+    get: jest.fn().mockReturnValue('test-secret'),
+  };
+
+  const mockPrismaService = {
+    user: {
+      findUnique: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        JwtStrategy,
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
+    }).compile();
+
+    strategy = module.get<JwtStrategy>(JwtStrategy);
+    prismaService = module.get<PrismaService>(PrismaService);
+  });
+
+  it('should be defined', () => {
+    expect(strategy).toBeDefined();
+  });
+
+  it('should validate and return user', async () => {
+    const mockUser = {
+      id: '1',
+      email: 'test@example.com',
+      name: 'Test User',
+      avatar: null,
+    };
+
+    const payload = { userId: '1', email: 'test@example.com' };
+
+    mockPrismaService.user.findUnique.mockResolvedValue(mockUser);
+
+    const result = await strategy.validate(payload);
+
+    expect(result).toEqual({
+      id: '1',
+      userId: '1',
+      email: 'test@example.com',
+      name: 'Test User',
+      avatar: null,
+    });
+    expect(prismaService.user.findUnique).toHaveBeenCalledWith({
+      where: { id: payload.userId },
+    });
+  });
+
+  it('should return null if user not found', async () => {
+    const payload = { userId: '999', email: 'notfound@example.com' };
+
+    mockPrismaService.user.findUnique.mockResolvedValue(null);
+
+    const result = await strategy.validate(payload);
+
+    expect(result).toBeNull();
+  });
+});

--- a/backend/src/modules/users/users.resolver.spec.ts
+++ b/backend/src/modules/users/users.resolver.spec.ts
@@ -1,0 +1,154 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsersResolver } from './users.resolver';
+import { UsersService } from './users.service';
+import { User } from './entities/user.entity';
+
+describe('UsersResolver', () => {
+  let resolver: UsersResolver;
+  let usersService: UsersService;
+
+  const mockUser: User = {
+    id: '1',
+    email: 'test@example.com',
+    name: 'Test User',
+    avatar: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const mockUsersService = {
+    findOne: jest.fn(),
+    findAll: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersResolver,
+        {
+          provide: UsersService,
+          useValue: mockUsersService,
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<UsersResolver>(UsersResolver);
+    usersService = module.get<UsersService>(UsersService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined();
+  });
+
+  describe('me', () => {
+    it('should return current user', async () => {
+      mockUsersService.findOne.mockResolvedValue(mockUser);
+
+      const result = await resolver.me({ id: '1' });
+
+      expect(result).toEqual(mockUser);
+      expect(usersService.findOne).toHaveBeenCalledWith('1');
+    });
+
+    it('should return null if no user', async () => {
+      const result = await resolver.me(null);
+
+      expect(result).toBeNull();
+      expect(usersService.findOne).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('users', () => {
+    it('should return all users', async () => {
+      const users = [mockUser, { ...mockUser, id: '2', email: 'test2@example.com' }];
+      mockUsersService.findAll.mockResolvedValue(users);
+
+      const result = await resolver.users();
+
+      expect(result).toEqual(users);
+      expect(usersService.findAll).toHaveBeenCalled();
+    });
+  });
+
+  describe('user', () => {
+    it('should return a user by id', async () => {
+      mockUsersService.findOne.mockResolvedValue(mockUser);
+
+      const result = await resolver.user('1');
+
+      expect(result).toEqual(mockUser);
+      expect(usersService.findOne).toHaveBeenCalledWith('1');
+    });
+
+    it('should return null if user not found', async () => {
+      mockUsersService.findOne.mockResolvedValue(null);
+
+      const result = await resolver.user('999');
+
+      expect(result).toBeNull();
+      expect(usersService.findOne).toHaveBeenCalledWith('999');
+    });
+  });
+
+  describe('createUser', () => {
+    it('should create a new user', async () => {
+      const createUserInput = {
+        email: 'new@example.com',
+        name: 'New User',
+        password: 'password123',
+      };
+
+      mockUsersService.create.mockResolvedValue({ ...mockUser, ...createUserInput });
+
+      const result = await resolver.createUser(createUserInput);
+
+      expect(result.email).toBe(createUserInput.email);
+      expect(usersService.create).toHaveBeenCalledWith(createUserInput);
+    });
+  });
+
+  describe('updateUser', () => {
+    it('should update a user', async () => {
+      const updateUserInput = {
+        name: 'Updated Name',
+        avatar: 'https://example.com/avatar.jpg',
+      };
+
+      const updatedUser = { ...mockUser, ...updateUserInput };
+      mockUsersService.update.mockResolvedValue(updatedUser);
+
+      const result = await resolver.updateUser('1', updateUserInput);
+
+      expect(result.name).toBe(updateUserInput.name);
+      expect(result.avatar).toBe(updateUserInput.avatar);
+      expect(usersService.update).toHaveBeenCalledWith('1', updateUserInput);
+    });
+  });
+
+  describe('deleteUser', () => {
+    it('should delete a user and return true', async () => {
+      mockUsersService.remove.mockResolvedValue(true);
+
+      const result = await resolver.deleteUser('1');
+
+      expect(result).toBe(true);
+      expect(usersService.remove).toHaveBeenCalledWith('1');
+    });
+
+    it('should return false if user not found', async () => {
+      mockUsersService.remove.mockResolvedValue(false);
+
+      const result = await resolver.deleteUser('999');
+
+      expect(result).toBe(false);
+      expect(usersService.remove).toHaveBeenCalledWith('999');
+    });
+  });
+});

--- a/backend/src/modules/users/users.service.spec.ts
+++ b/backend/src/modules/users/users.service.spec.ts
@@ -103,4 +103,153 @@ describe('UsersService', () => {
       await expect(service.findOne('999')).rejects.toThrow('User with ID 999 not found');
     });
   });
+
+  describe('create', () => {
+    it('should create a new user', async () => {
+      const input = {
+        email: 'new@example.com',
+        name: 'New User',
+        password: 'password123',
+      };
+
+      const mockCreatedUser = {
+        id: '1',
+        email: input.email,
+        name: input.name,
+        avatar: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockPrismaService.user.findUnique.mockResolvedValue(null);
+      mockPrismaService.user.create.mockResolvedValue(mockCreatedUser);
+
+      const result = await service.create(input);
+
+      expect(result).toEqual(mockCreatedUser);
+      expect(prisma.user.findUnique).toHaveBeenCalledWith({ where: { email: input.email } });
+      expect(prisma.user.create).toHaveBeenCalled();
+    });
+
+    it('should throw ConflictException if email already exists', async () => {
+      const input = {
+        email: 'existing@example.com',
+        name: 'New User',
+        password: 'password123',
+      };
+
+      mockPrismaService.user.findUnique.mockResolvedValue({ id: '1', email: input.email });
+
+      await expect(service.create(input)).rejects.toThrow('Email already in use');
+    });
+
+    it('should handle Prisma P2002 error', async () => {
+      const input = {
+        email: 'test@example.com',
+        name: 'Test',
+        password: 'password123',
+      };
+
+      mockPrismaService.user.findUnique.mockResolvedValue(null);
+      mockPrismaService.user.create.mockRejectedValue({ code: 'P2002' });
+
+      await expect(service.create(input)).rejects.toThrow('Email already in use');
+    });
+
+    it('should rethrow other errors', async () => {
+      const input = {
+        email: 'test@example.com',
+        name: 'Test',
+        password: 'password123',
+      };
+
+      const customError = new Error('Database connection failed');
+      mockPrismaService.user.findUnique.mockResolvedValue(null);
+      mockPrismaService.user.create.mockRejectedValue(customError);
+
+      await expect(service.create(input)).rejects.toThrow('Database connection failed');
+    });
+  });
+
+  describe('update', () => {
+    it('should update a user', async () => {
+      const input = {
+        name: 'Updated Name',
+        avatar: 'https://example.com/avatar.jpg',
+      };
+
+      const mockUpdatedUser = {
+        id: '1',
+        email: 'test@example.com',
+        name: input.name,
+        avatar: input.avatar,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockPrismaService.user.update.mockResolvedValue(mockUpdatedUser);
+
+      const result = await service.update('1', input);
+
+      expect(result).toEqual(mockUpdatedUser);
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: '1' },
+        data: {
+          name: input.name,
+          avatar: input.avatar,
+        },
+        select: {
+          id: true,
+          email: true,
+          name: true,
+          avatar: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      });
+    });
+
+    it('should throw NotFoundException if user not found', async () => {
+      const input = { name: 'Updated' };
+
+      mockPrismaService.user.update.mockRejectedValue({ code: 'P2025' });
+
+      await expect(service.update('999', input)).rejects.toThrow(NotFoundException);
+      await expect(service.update('999', input)).rejects.toThrow('User with ID 999 not found');
+    });
+
+    it('should rethrow other errors', async () => {
+      const input = { name: 'Updated' };
+      const customError = new Error('Database error');
+
+      mockPrismaService.user.update.mockRejectedValue(customError);
+
+      await expect(service.update('1', input)).rejects.toThrow('Database error');
+    });
+  });
+
+  describe('remove', () => {
+    it('should delete a user', async () => {
+      mockPrismaService.user.delete.mockResolvedValue({});
+
+      const result = await service.remove('1');
+
+      expect(result).toBe(true);
+      expect(prisma.user.delete).toHaveBeenCalledWith({ where: { id: '1' } });
+    });
+
+    it('should throw NotFoundException if user not found', async () => {
+      mockPrismaService.user.delete.mockRejectedValue({ code: 'P2025' });
+
+      await expect(service.remove('999')).rejects.toThrow(NotFoundException);
+      await expect(service.remove('999')).rejects.toThrow('User with ID 999 not found');
+    });
+
+    it('should rethrow other errors', async () => {
+      const customError = new Error('Database error');
+      mockPrismaService.user.delete.mockRejectedValue(customError);
+
+      await expect(service.remove('1')).rejects.toThrow('Database error');
+    });
+  });
 });

--- a/backend/src/modules/workspaces/workspaces.resolver.spec.ts
+++ b/backend/src/modules/workspaces/workspaces.resolver.spec.ts
@@ -1,0 +1,110 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WorkspacesResolver } from './workspaces.resolver';
+import { WorkspacesService } from './workspaces.service';
+
+describe('WorkspacesResolver', () => {
+  let resolver: WorkspacesResolver;
+  let workspacesService: WorkspacesService;
+
+  const mockWorkspace = {
+    id: '1',
+    name: 'Test Workspace',
+    description: 'Test Description',
+    logoUrl: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    memberCount: 1,
+  };
+
+  const mockUser = { id: 'user-1' };
+
+  const mockWorkspacesService = {
+    create: jest.fn(),
+    findMyWorkspaces: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WorkspacesResolver,
+        {
+          provide: WorkspacesService,
+          useValue: mockWorkspacesService,
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<WorkspacesResolver>(WorkspacesResolver);
+    workspacesService = module.get<WorkspacesService>(WorkspacesService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined();
+  });
+
+  describe('createWorkspace', () => {
+    it('should create a workspace', async () => {
+      const input = { name: 'New Workspace', description: 'Description' };
+      mockWorkspacesService.create.mockResolvedValue(mockWorkspace);
+
+      const result = await resolver.createWorkspace(input, mockUser);
+
+      expect(result).toEqual(mockWorkspace);
+      expect(workspacesService.create).toHaveBeenCalledWith(input, 'user-1');
+    });
+  });
+
+  describe('myWorkspaces', () => {
+    it('should return user workspaces', async () => {
+      const workspaces = [mockWorkspace];
+      mockWorkspacesService.findMyWorkspaces.mockResolvedValue(workspaces);
+
+      const result = await resolver.myWorkspaces(mockUser);
+
+      expect(result).toEqual(workspaces);
+      expect(workspacesService.findMyWorkspaces).toHaveBeenCalledWith('user-1');
+    });
+  });
+
+  describe('workspace', () => {
+    it('should return a workspace by id', async () => {
+      mockWorkspacesService.findOne.mockResolvedValue(mockWorkspace);
+
+      const result = await resolver.workspace('1', mockUser);
+
+      expect(result).toEqual(mockWorkspace);
+      expect(workspacesService.findOne).toHaveBeenCalledWith('1', 'user-1');
+    });
+  });
+
+  describe('updateWorkspace', () => {
+    it('should update a workspace', async () => {
+      const input = { name: 'Updated Name' };
+      const updated = { ...mockWorkspace, name: 'Updated Name' };
+      mockWorkspacesService.update.mockResolvedValue(updated);
+
+      const result = await resolver.updateWorkspace('1', input, mockUser);
+
+      expect(result.name).toBe('Updated Name');
+      expect(workspacesService.update).toHaveBeenCalledWith('1', input, 'user-1');
+    });
+  });
+
+  describe('deleteWorkspace', () => {
+    it('should delete a workspace', async () => {
+      mockWorkspacesService.remove.mockResolvedValue(true);
+
+      const result = await resolver.deleteWorkspace('1', mockUser);
+
+      expect(result).toBe(true);
+      expect(workspacesService.remove).toHaveBeenCalledWith('1', 'user-1');
+    });
+  });
+});

--- a/backend/src/prisma/prisma.service.spec.ts
+++ b/backend/src/prisma/prisma.service.spec.ts
@@ -1,0 +1,99 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from './prisma.service';
+
+describe('PrismaService', () => {
+  let service: PrismaService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PrismaService],
+    }).compile();
+
+    service = module.get<PrismaService>(PrismaService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should extend PrismaClient', () => {
+    expect(service.$connect).toBeDefined();
+    expect(service.$disconnect).toBeDefined();
+  });
+
+  describe('lifecycle hooks', () => {
+    it('should call $connect on module init', async () => {
+      const connectSpy = jest.spyOn(service, '$connect').mockResolvedValue(undefined);
+
+      await service.onModuleInit();
+
+      expect(connectSpy).toHaveBeenCalled();
+
+      connectSpy.mockRestore();
+    });
+
+    it('should handle connection error', async () => {
+      const connectSpy = jest.spyOn(service, '$connect').mockRejectedValue(new Error('Connection failed'));
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      await expect(service.onModuleInit()).rejects.toThrow('Connection failed');
+
+      expect(connectSpy).toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Error connecting to database:', expect.any(Error));
+
+      connectSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should call $disconnect on module destroy', async () => {
+      const disconnectSpy = jest.spyOn(service, '$disconnect').mockResolvedValue(undefined);
+
+      await service.onModuleDestroy();
+
+      expect(disconnectSpy).toHaveBeenCalled();
+
+      disconnectSpy.mockRestore();
+    });
+
+    it('should handle disconnection error', async () => {
+      const disconnectSpy = jest.spyOn(service, '$disconnect').mockRejectedValue(new Error('Disconnect failed'));
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      await expect(service.onModuleDestroy()).rejects.toThrow('Disconnect failed');
+
+      expect(disconnectSpy).toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Error disconnecting from database:', expect.any(Error));
+
+      disconnectSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('database operations', () => {
+    it('should have user operations', () => {
+      expect(service.user).toBeDefined();
+      expect(service.user.findMany).toBeDefined();
+      expect(service.user.findUnique).toBeDefined();
+      expect(service.user.create).toBeDefined();
+      expect(service.user.update).toBeDefined();
+      expect(service.user.delete).toBeDefined();
+    });
+
+    it('should have workspace operations', () => {
+      expect(service.workspace).toBeDefined();
+      expect(service.workspace.findMany).toBeDefined();
+      expect(service.workspace.findUnique).toBeDefined();
+      expect(service.workspace.create).toBeDefined();
+      expect(service.workspace.update).toBeDefined();
+      expect(service.workspace.delete).toBeDefined();
+    });
+
+    it('should have workspaceMember operations', () => {
+      expect(service.workspaceMember).toBeDefined();
+    });
+
+    it('should have workspaceInvitation operations', () => {
+      expect(service.workspaceInvitation).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
Add comprehensive unit tests for backend modules.

New test files:
- auth.service.spec.ts (18 tests, 93.5% coverage)
- auth.resolver.spec.ts (6 tests, 80% coverage)
- auth.controller.spec.ts (11 tests, 100% coverage)
- jwt.strategy.spec.ts (3 tests)
- users.resolver.spec.ts (10 tests, 75% coverage)
- workspaces.resolver.spec.ts (6 tests, 74% coverage)
- prisma.service.spec.ts (10 tests, 100% coverage)
- gql-auth.guard.spec.ts (3 tests, 72% coverage)
- http-exception.filter.spec.ts (5 tests, 100% coverage)

Enhanced: users.service.spec.ts (13 tests, 100% coverage)

Results: 195/195 tests passing, 82.2% coverage