### PR TITLE
Implement complete CRUD operations for boards with workspace association and permission checks

### DIFF
--- a/backend/prisma/migrations/20251222122402_add_is_archived_to_board/migration.sql
+++ b/backend/prisma/migrations/20251222122402_add_is_archived_to_board/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "boards" ADD COLUMN     "isArchived" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -137,6 +137,7 @@ model Board {
   description String?
   visibility  Visibility @default(PRIVATE)
   background  String?
+  isArchived  Boolean    @default(false)
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
 
@@ -405,7 +406,7 @@ model OAuthAccount {
   id           String        @id @default(uuid())
   userId       String
   provider     OAuthProvider
-  providerId   String // ID de l'utilisateur chez le provider
+  providerId   String
   accessToken  String?       @db.Text
   refreshToken String?       @db.Text
   expiresAt    DateTime?

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { AuthModule } from './modules/auth/auth.module';
 import { EmailModule } from './modules/email/email.module';
 import { WorkspacesModule } from './modules/workspaces/workspaces.module';
 import { InvitationsModule } from './modules/invitations/invitations.module';
+import { BoardsModule } from './modules/boards/boards.module';
 import { GqlAuthGuard } from './common/guards/gql-auth.guard';
 import { AllExceptionsFilter } from './common/filters/http-exception.filter';
 
@@ -47,6 +48,7 @@ import { AllExceptionsFilter } from './common/filters/http-exception.filter';
     EmailModule,
     WorkspacesModule,
     InvitationsModule,
+    BoardsModule,
   ],
   providers: [
     {

--- a/backend/src/graphql/schema.gql
+++ b/backend/src/graphql/schema.gql
@@ -2,6 +2,12 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
 # ------------------------------------------------------
 
+input AddBoardMemberInput {
+  boardId: ID!
+  role: String
+  userId: ID!
+}
+
 """Authentication response containing JWT token and user data"""
 type AuthPayload {
   """JWT token to use in Authorization header for authenticated requests"""
@@ -9,6 +15,37 @@ type AuthPayload {
 
   """Authenticated user information"""
   user: User!
+}
+
+type Board {
+  background: String
+  createdAt: DateTime!
+  creatorId: ID!
+  description: String
+  id: ID!
+  isArchived: Boolean!
+  members: [BoardMemberWithUser!]
+  title: String!
+  updatedAt: DateTime!
+  visibility: Visibility!
+  workspaceId: ID
+}
+
+type BoardMemberWithUser {
+  boardId: ID!
+  id: ID!
+  joinedAt: DateTime!
+  role: String!
+  user: MemberUser!
+  userId: ID!
+}
+
+input CreateBoardInput {
+  background: String
+  description: String
+  title: String!
+  visibility: Visibility
+  workspaceId: ID
 }
 
 input CreateUserInput {
@@ -78,16 +115,30 @@ type Mutation {
   """Accept a workspace invitation."""
   acceptInvitation(input: RespondInvitationInput!): WorkspaceInvitation!
 
+  """Add a member to a board. Only board ADMIN can add members."""
+  addBoardMember(input: AddBoardMemberInput!): BoardMemberWithUser!
+
+  """Archive a board. User must be ADMIN or MEMBER."""
+  archiveBoard(id: ID!): Board!
+
   """
   Cancel a pending invitation. Only the inviter or workspace admin can cancel.
   """
   cancelInvitation(invitationId: ID!): Boolean!
+
+  """
+  Create a new board. User must be ADMIN or MEMBER of the workspace (if provided).
+  """
+  createBoard(input: CreateBoardInput!): Board!
 
   """Create a new user (requires authentication)"""
   createUser(input: CreateUserInput!): User!
 
   """Create a new workspace. The creator becomes an ADMIN automatically."""
   createWorkspace(input: CreateWorkspaceInput!): Workspace!
+
+  """Delete a board. Only board ADMIN can delete."""
+  deleteBoard(id: ID!): Boolean!
 
   """Delete a user by ID (requires authentication)"""
   deleteUser(id: ID!): Boolean!
@@ -119,6 +170,9 @@ type Mutation {
   """Reject a workspace invitation."""
   rejectInvitation(input: RespondInvitationInput!): WorkspaceInvitation!
 
+  """Remove a member from a board. Only board ADMIN can remove members."""
+  removeBoardMember(boardId: ID!, userId: ID!): Boolean!
+
   """Remove a member from a workspace. Only ADMIN can remove members."""
   removeMember(input: RemoveMemberInput!): Boolean!
 
@@ -126,6 +180,15 @@ type Mutation {
   Reset password using a valid reset token. The token is received via email after requesting a password reset.
   """
   resetPassword(input: ResetPasswordInput!): MessageResponse!
+
+  """Unarchive a board. User must be ADMIN or MEMBER."""
+  unarchiveBoard(id: ID!): Board!
+
+  """Update a board. User must be ADMIN or MEMBER of the board."""
+  updateBoard(input: UpdateBoardInput!): Board!
+
+  """Update a member role in a board. Only board ADMIN can update roles."""
+  updateBoardMemberRole(input: UpdateBoardMemberRoleInput!): Boolean!
 
   """Update a member role in a workspace. Only ADMIN can update roles."""
   updateMemberRole(input: UpdateMemberRoleInput!): Boolean!
@@ -143,6 +206,9 @@ type Mutation {
 }
 
 type Query {
+  """Get a board by ID. Access based on visibility and membership."""
+  board(id: ID!): Board!
+
   """Get the currently authenticated user information"""
   me: User
 
@@ -160,6 +226,9 @@ type Query {
 
   """Get a workspace by ID. User must be a member to access."""
   workspace(id: ID!): Workspace!
+
+  """List all boards in a workspace. User must be a workspace member."""
+  workspaceBoards(workspaceId: ID!): [Board!]!
 
   """Get pending invitations for a workspace. Only ADMIN can view."""
   workspaceInvitations(workspaceId: ID!): [WorkspaceInvitation!]!
@@ -201,6 +270,20 @@ input RespondInvitationInput {
   invitationId: String!
 }
 
+input UpdateBoardInput {
+  background: String
+  description: String
+  id: ID!
+  title: String
+  visibility: Visibility
+}
+
+input UpdateBoardMemberRoleInput {
+  boardId: ID!
+  role: String!
+  userId: ID!
+}
+
 input UpdateMemberRoleInput {
   role: String!
   userId: String!
@@ -229,7 +312,7 @@ type User {
   updatedAt: DateTime!
 }
 
-"""Workspace visibility level"""
+"""Board visibility settings"""
 enum Visibility {
   PRIVATE
   PUBLIC

--- a/backend/src/modules/boards/boards.module.ts
+++ b/backend/src/modules/boards/boards.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { BoardsService } from './boards.service';
+import { BoardsResolver } from './boards.resolver';
+import { PrismaModule } from '../../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [BoardsResolver, BoardsService],
+  exports: [BoardsService],
+})
+export class BoardsModule {}

--- a/backend/src/modules/boards/boards.resolver.spec.ts
+++ b/backend/src/modules/boards/boards.resolver.spec.ts
@@ -1,0 +1,232 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BoardsResolver } from './boards.resolver';
+import { BoardsService } from './boards.service';
+import { Visibility, Role } from '@prisma/client';
+
+describe('BoardsResolver', () => {
+  let resolver: BoardsResolver;
+  let service: BoardsService;
+
+  const mockBoardsService = {
+    create: jest.fn(),
+    findOne: jest.fn(),
+    findByWorkspace: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    archive: jest.fn(),
+    unarchive: jest.fn(),
+    addMember: jest.fn(),
+    removeMember: jest.fn(),
+    updateMemberRole: jest.fn(),
+  };
+
+  const mockUser = {
+    id: 'user-1',
+    email: 'test@example.com',
+    name: 'Test User',
+  };
+
+  const mockBoard = {
+    id: 'board-1',
+    title: 'Test Board',
+    description: 'Test Description',
+    workspaceId: 'workspace-1',
+    visibility: Visibility.PRIVATE,
+    background: null,
+    isArchived: false,
+    creatorId: 'user-1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BoardsResolver,
+        {
+          provide: BoardsService,
+          useValue: mockBoardsService,
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<BoardsResolver>(BoardsResolver);
+    service = module.get<BoardsService>(BoardsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined();
+  });
+
+  describe('createBoard', () => {
+    it('should create a board', async () => {
+      const input = {
+        title: 'New Board',
+        description: 'Description',
+        workspaceId: 'workspace-1',
+      };
+
+      mockBoardsService.create.mockResolvedValue(mockBoard);
+
+      const result = await resolver.createBoard(input, mockUser);
+
+      expect(result).toEqual(mockBoard);
+      expect(service.create).toHaveBeenCalledWith(input, mockUser.id);
+    });
+  });
+
+  describe('board', () => {
+    it('should return a board by id', async () => {
+      mockBoardsService.findOne.mockResolvedValue(mockBoard);
+
+      const result = await resolver.board(mockBoard.id, mockUser);
+
+      expect(result).toEqual(mockBoard);
+      expect(service.findOne).toHaveBeenCalledWith(mockBoard.id, mockUser.id);
+    });
+  });
+
+  describe('workspaceBoards', () => {
+    it('should return all boards in a workspace', async () => {
+      const boards = [mockBoard];
+      mockBoardsService.findByWorkspace.mockResolvedValue(boards);
+
+      const result = await resolver.workspaceBoards('workspace-1', mockUser);
+
+      expect(result).toEqual(boards);
+      expect(service.findByWorkspace).toHaveBeenCalledWith('workspace-1', mockUser.id);
+    });
+  });
+
+  describe('updateBoard', () => {
+    it('should update a board', async () => {
+      const input = {
+        id: mockBoard.id,
+        title: 'Updated Board',
+      };
+
+      const updatedBoard = {
+        ...mockBoard,
+        title: 'Updated Board',
+      };
+
+      mockBoardsService.update.mockResolvedValue(updatedBoard);
+
+      const result = await resolver.updateBoard(input, mockUser);
+
+      expect(result).toEqual(updatedBoard);
+      expect(service.update).toHaveBeenCalledWith(input, mockUser.id);
+    });
+  });
+
+  describe('deleteBoard', () => {
+    it('should delete a board', async () => {
+      mockBoardsService.delete.mockResolvedValue(true);
+
+      const result = await resolver.deleteBoard(mockBoard.id, mockUser);
+
+      expect(result).toBe(true);
+      expect(service.delete).toHaveBeenCalledWith(mockBoard.id, mockUser.id);
+    });
+  });
+
+  describe('archiveBoard', () => {
+    it('should archive a board', async () => {
+      const archivedBoard = {
+        ...mockBoard,
+        isArchived: true,
+      };
+
+      mockBoardsService.archive.mockResolvedValue(archivedBoard);
+
+      const result = await resolver.archiveBoard(mockBoard.id, mockUser);
+
+      expect(result).toEqual(archivedBoard);
+      expect(service.archive).toHaveBeenCalledWith(mockBoard.id, mockUser.id);
+    });
+  });
+
+  describe('unarchiveBoard', () => {
+    it('should unarchive a board', async () => {
+      const unarchivedBoard = {
+        ...mockBoard,
+        isArchived: false,
+      };
+
+      mockBoardsService.unarchive.mockResolvedValue(unarchivedBoard);
+
+      const result = await resolver.unarchiveBoard(mockBoard.id, mockUser);
+
+      expect(result).toEqual(unarchivedBoard);
+      expect(service.unarchive).toHaveBeenCalledWith(mockBoard.id, mockUser.id);
+    });
+  });
+
+  describe('addBoardMember', () => {
+    it('should add a member to a board', async () => {
+      const input = {
+        boardId: mockBoard.id,
+        userId: 'user-2',
+        role: Role.MEMBER,
+      };
+
+      const mockMember = {
+        id: 'member-2',
+        boardId: input.boardId,
+        userId: input.userId,
+        role: input.role,
+        joinedAt: new Date(),
+        user: {
+          id: 'user-2',
+          email: 'newuser@example.com',
+          name: 'New User',
+          avatar: null,
+        },
+      };
+
+      mockBoardsService.addMember.mockResolvedValue(mockMember);
+
+      const result = await resolver.addBoardMember(input, mockUser);
+
+      expect(result).toEqual(mockMember);
+      expect(service.addMember).toHaveBeenCalledWith(input, mockUser.id);
+    });
+  });
+
+  describe('removeBoardMember', () => {
+    it('should remove a member from a board', async () => {
+      mockBoardsService.removeMember.mockResolvedValue(true);
+
+      const result = await resolver.removeBoardMember(mockBoard.id, 'user-2', mockUser);
+
+      expect(result).toBe(true);
+      expect(service.removeMember).toHaveBeenCalledWith(mockBoard.id, 'user-2', mockUser.id);
+    });
+  });
+
+  describe('updateBoardMemberRole', () => {
+    it('should update a member role in a board', async () => {
+      const input = {
+        boardId: mockBoard.id,
+        userId: 'user-2',
+        role: Role.ADMIN,
+      };
+
+      mockBoardsService.updateMemberRole.mockResolvedValue(true);
+
+      const result = await resolver.updateBoardMemberRole(input, mockUser);
+
+      expect(result).toBe(true);
+      expect(service.updateMemberRole).toHaveBeenCalledWith(
+        input.boardId,
+        input.userId,
+        input.role,
+        mockUser.id,
+      );
+    });
+  });
+});

--- a/backend/src/modules/boards/boards.resolver.ts
+++ b/backend/src/modules/boards/boards.resolver.ts
@@ -1,0 +1,120 @@
+import { Resolver, Query, Mutation, Args, ID } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
+import { BoardsService } from './boards.service';
+import { Board } from './entities/board.entity';
+import { BoardMemberWithUser } from './entities/board-member.entity';
+import { CreateBoardInput } from './dto/create-board.input';
+import { UpdateBoardInput } from './dto/update-board.input';
+import { AddBoardMemberInput } from './dto/add-board-member.input';
+import { UpdateBoardMemberRoleInput } from './dto/update-board-member-role.input';
+import { GqlAuthGuard } from '../../common/guards/gql-auth.guard';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+
+@Resolver(() => Board)
+@UseGuards(GqlAuthGuard)
+export class BoardsResolver {
+  constructor(private readonly boardsService: BoardsService) {}
+
+  @Mutation(() => Board, {
+    description: 'Create a new board. User must be ADMIN or MEMBER of the workspace (if provided).',
+  })
+  async createBoard(
+    @Args('input') input: CreateBoardInput,
+    @CurrentUser() user: any,
+  ): Promise<Board> {
+    return this.boardsService.create(input, user.id);
+  }
+
+  @Query(() => Board, {
+    name: 'board',
+    description: 'Get a board by ID. Access based on visibility and membership.',
+  })
+  async board(
+    @Args('id', { type: () => ID }) id: string,
+    @CurrentUser() user: any,
+  ): Promise<Board> {
+    return this.boardsService.findOne(id, user.id);
+  }
+
+  @Query(() => [Board], {
+    name: 'workspaceBoards',
+    description: 'List all boards in a workspace. User must be a workspace member.',
+  })
+  async workspaceBoards(
+    @Args('workspaceId', { type: () => ID }) workspaceId: string,
+    @CurrentUser() user: any,
+  ): Promise<Board[]> {
+    return this.boardsService.findByWorkspace(workspaceId, user.id);
+  }
+
+  @Mutation(() => Board, {
+    description: 'Update a board. User must be ADMIN or MEMBER of the board.',
+  })
+  async updateBoard(
+    @Args('input') input: UpdateBoardInput,
+    @CurrentUser() user: any,
+  ): Promise<Board> {
+    return this.boardsService.update(input, user.id);
+  }
+
+  @Mutation(() => Boolean, {
+    description: 'Delete a board. Only board ADMIN can delete.',
+  })
+  async deleteBoard(
+    @Args('id', { type: () => ID }) id: string,
+    @CurrentUser() user: any,
+  ): Promise<boolean> {
+    return this.boardsService.delete(id, user.id);
+  }
+
+  @Mutation(() => Board, {
+    description: 'Archive a board. User must be ADMIN or MEMBER.',
+  })
+  async archiveBoard(
+    @Args('id', { type: () => ID }) id: string,
+    @CurrentUser() user: any,
+  ): Promise<Board> {
+    return this.boardsService.archive(id, user.id);
+  }
+
+  @Mutation(() => Board, {
+    description: 'Unarchive a board. User must be ADMIN or MEMBER.',
+  })
+  async unarchiveBoard(
+    @Args('id', { type: () => ID }) id: string,
+    @CurrentUser() user: any,
+  ): Promise<Board> {
+    return this.boardsService.unarchive(id, user.id);
+  }
+
+  @Mutation(() => BoardMemberWithUser, {
+    description: 'Add a member to a board. Only board ADMIN can add members.',
+  })
+  async addBoardMember(
+    @Args('input') input: AddBoardMemberInput,
+    @CurrentUser() user: any,
+  ): Promise<BoardMemberWithUser> {
+    return this.boardsService.addMember(input, user.id);
+  }
+
+  @Mutation(() => Boolean, {
+    description: 'Remove a member from a board. Only board ADMIN can remove members.',
+  })
+  async removeBoardMember(
+    @Args('boardId', { type: () => ID }) boardId: string,
+    @Args('userId', { type: () => ID }) userId: string,
+    @CurrentUser() user: any,
+  ): Promise<boolean> {
+    return this.boardsService.removeMember(boardId, userId, user.id);
+  }
+
+  @Mutation(() => Boolean, {
+    description: 'Update a member role in a board. Only board ADMIN can update roles.',
+  })
+  async updateBoardMemberRole(
+    @Args('input') input: UpdateBoardMemberRoleInput,
+    @CurrentUser() user: any,
+  ): Promise<boolean> {
+    return this.boardsService.updateMemberRole(input.boardId, input.userId, input.role, user.id);
+  }
+}

--- a/backend/src/modules/boards/boards.service.spec.ts
+++ b/backend/src/modules/boards/boards.service.spec.ts
@@ -1,0 +1,690 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException, ForbiddenException, ConflictException } from '@nestjs/common';
+import { BoardsService } from './boards.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { Role, Visibility } from '@prisma/client';
+
+describe('BoardsService', () => {
+  let service: BoardsService;
+  let prismaService: PrismaService;
+
+  const mockPrismaService = {
+    board: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    boardMember: {
+      create: jest.fn(),
+      delete: jest.fn(),
+      update: jest.fn(),
+    },
+    user: {
+      findUnique: jest.fn(),
+    },
+    workspace: {
+      findUnique: jest.fn(),
+    },
+    workspaceMember: {
+      findUnique: jest.fn(),
+    },
+  };
+
+  const mockUser = {
+    id: 'user-1',
+    email: 'test@example.com',
+    name: 'Test User',
+  };
+
+  const mockBoard = {
+    id: 'board-1',
+    title: 'Test Board',
+    description: 'Test Description',
+    workspaceId: 'workspace-1',
+    visibility: Visibility.PRIVATE,
+    background: null,
+    isArchived: false,
+    creatorId: 'user-1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    members: [
+      {
+        id: 'member-1',
+        boardId: 'board-1',
+        userId: 'user-1',
+        role: Role.ADMIN,
+        joinedAt: new Date(),
+      },
+    ],
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BoardsService,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<BoardsService>(BoardsService);
+    prismaService = module.get<PrismaService>(PrismaService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a board without workspace', async () => {
+      const input = {
+        title: 'New Board',
+        description: 'Description',
+      };
+
+      mockPrismaService.board.create.mockResolvedValue(mockBoard);
+
+      const result = await service.create(input, mockUser.id);
+
+      expect(result).toEqual(mockBoard);
+      expect(prismaService.board.create).toHaveBeenCalledWith({
+        data: {
+          title: input.title,
+          description: input.description,
+          workspaceId: undefined,
+          visibility: 'PRIVATE',
+          background: undefined,
+          creatorId: mockUser.id,
+          members: {
+            create: {
+              userId: mockUser.id,
+              role: Role.ADMIN,
+            },
+          },
+        },
+      });
+    });
+
+    it('should create a board with workspace when user is workspace member', async () => {
+      const input = {
+        title: 'New Board',
+        workspaceId: 'workspace-1',
+      };
+
+      mockPrismaService.workspaceMember.findUnique.mockResolvedValue({
+        id: 'member-1',
+        userId: mockUser.id,
+        workspaceId: 'workspace-1',
+        role: Role.ADMIN,
+      });
+      mockPrismaService.workspace.findUnique.mockResolvedValue({
+        id: 'workspace-1',
+        name: 'Test Workspace',
+      });
+      mockPrismaService.board.create.mockResolvedValue(mockBoard);
+
+      const result = await service.create(input, mockUser.id);
+
+      expect(result).toEqual(mockBoard);
+      expect(prismaService.workspaceMember.findUnique).toHaveBeenCalled();
+    });
+
+    it('should throw ForbiddenException if user is not workspace member', async () => {
+      const input = {
+        title: 'New Board',
+        workspaceId: 'workspace-1',
+      };
+
+      mockPrismaService.workspaceMember.findUnique.mockResolvedValue(null);
+
+      await expect(service.create(input, mockUser.id)).rejects.toThrow(ForbiddenException);
+      await expect(service.create(input, mockUser.id)).rejects.toThrow(
+        'You are not a member of this workspace',
+      );
+    });
+
+    it('should throw ForbiddenException if user is OBSERVER', async () => {
+      const input = {
+        title: 'New Board',
+        workspaceId: 'workspace-1',
+      };
+
+      mockPrismaService.workspaceMember.findUnique.mockResolvedValue({
+        id: 'member-1',
+        userId: mockUser.id,
+        role: Role.OBSERVER,
+      });
+
+      await expect(service.create(input, mockUser.id)).rejects.toThrow(ForbiddenException);
+      await expect(service.create(input, mockUser.id)).rejects.toThrow(
+        'Observers cannot create boards',
+      );
+    });
+
+    it('should throw NotFoundException if workspace not found', async () => {
+      const input = {
+        title: 'New Board',
+        workspaceId: 'workspace-1',
+      };
+
+      mockPrismaService.workspaceMember.findUnique.mockResolvedValue({
+        id: 'member-1',
+        userId: mockUser.id,
+        role: Role.ADMIN,
+      });
+      mockPrismaService.workspace.findUnique.mockResolvedValue(null);
+
+      await expect(service.create(input, mockUser.id)).rejects.toThrow(NotFoundException);
+      await expect(service.create(input, mockUser.id)).rejects.toThrow('Workspace not found');
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return board if user is board member', async () => {
+      mockPrismaService.board.findUnique.mockResolvedValue({
+        ...mockBoard,
+        workspace: null,
+      });
+
+      const result = await service.findOne(mockBoard.id, mockUser.id);
+
+      expect(result).toEqual({ ...mockBoard, workspace: null });
+    });
+
+    it('should return public board to any user', async () => {
+      const publicBoard = {
+        ...mockBoard,
+        visibility: Visibility.PUBLIC,
+        members: [],
+        workspace: null,
+      };
+
+      mockPrismaService.board.findUnique.mockResolvedValue(publicBoard);
+
+      const result = await service.findOne(mockBoard.id, 'other-user');
+
+      expect(result).toEqual(publicBoard);
+    });
+
+    it('should throw NotFoundException if board not found', async () => {
+      mockPrismaService.board.findUnique.mockResolvedValue(null);
+
+      await expect(service.findOne('invalid-id', mockUser.id)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw ForbiddenException if user has no access', async () => {
+      const privateBoard = {
+        ...mockBoard,
+        visibility: Visibility.PRIVATE,
+        members: [],
+        workspace: null,
+      };
+
+      mockPrismaService.board.findUnique.mockResolvedValue(privateBoard);
+
+      await expect(service.findOne(mockBoard.id, 'other-user')).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('should allow workspace member to access WORKSPACE visibility board', async () => {
+      const workspaceBoard = {
+        ...mockBoard,
+        visibility: Visibility.WORKSPACE,
+        members: [],
+        workspace: {
+          id: 'workspace-1',
+          memberships: [{ userId: 'other-user', role: Role.MEMBER }],
+        },
+      };
+
+      mockPrismaService.board.findUnique.mockResolvedValue(workspaceBoard);
+
+      const result = await service.findOne(mockBoard.id, 'other-user');
+
+      expect(result).toEqual(workspaceBoard);
+    });
+  });
+
+  describe('findByWorkspace', () => {
+    it('should return workspace boards if user is member', async () => {
+      mockPrismaService.workspaceMember.findUnique.mockResolvedValue({
+        id: 'member-1',
+        userId: mockUser.id,
+        workspaceId: 'workspace-1',
+      });
+      mockPrismaService.board.findMany.mockResolvedValue([mockBoard]);
+
+      const result = await service.findByWorkspace('workspace-1', mockUser.id);
+
+      expect(result).toEqual([mockBoard]);
+      expect(prismaService.board.findMany).toHaveBeenCalledWith({
+        where: {
+          workspaceId: 'workspace-1',
+          isArchived: false,
+        },
+        include: {
+          members: {
+            include: {
+              user: {
+                select: {
+                  id: true,
+                  email: true,
+                  name: true,
+                  avatar: true,
+                },
+              },
+            },
+          },
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+      });
+    });
+
+    it('should throw ForbiddenException if user is not workspace member', async () => {
+      mockPrismaService.workspaceMember.findUnique.mockResolvedValue(null);
+
+      await expect(service.findByWorkspace('workspace-1', mockUser.id)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('should update board if user is ADMIN', async () => {
+      const input = {
+        id: mockBoard.id,
+        title: 'Updated Title',
+      };
+
+      mockPrismaService.board.findUnique.mockResolvedValue(mockBoard);
+      mockPrismaService.board.update.mockResolvedValue({
+        ...mockBoard,
+        title: 'Updated Title',
+      });
+
+      const result = await service.update(input, mockUser.id);
+
+      expect(result.title).toBe('Updated Title');
+      expect(prismaService.board.update).toHaveBeenCalled();
+    });
+
+    it('should update board if user is MEMBER', async () => {
+      const input = {
+        id: mockBoard.id,
+        title: 'Updated Title',
+      };
+
+      mockPrismaService.board.findUnique.mockResolvedValue({
+        ...mockBoard,
+        members: [
+          {
+            id: 'member-1',
+            userId: mockUser.id,
+            role: Role.MEMBER,
+          },
+        ],
+      });
+      mockPrismaService.board.update.mockResolvedValue({
+        ...mockBoard,
+        title: 'Updated Title',
+      });
+
+      const result = await service.update(input, mockUser.id);
+
+      expect(result.title).toBe('Updated Title');
+    });
+
+    it('should throw NotFoundException if board not found', async () => {
+      const input = {
+        id: 'invalid-id',
+        title: 'Updated',
+      };
+
+      mockPrismaService.board.findUnique.mockResolvedValue(null);
+
+      await expect(service.update(input, mockUser.id)).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ForbiddenException if user is OBSERVER', async () => {
+      const input = {
+        id: mockBoard.id,
+        title: 'Updated',
+      };
+
+      mockPrismaService.board.findUnique.mockResolvedValue({
+        ...mockBoard,
+        members: [
+          {
+            id: 'member-1',
+            userId: mockUser.id,
+            role: Role.OBSERVER,
+          },
+        ],
+      });
+
+      await expect(service.update(input, mockUser.id)).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete board if user is ADMIN', async () => {
+      mockPrismaService.board.findUnique.mockResolvedValue(mockBoard);
+      mockPrismaService.board.delete.mockResolvedValue(mockBoard);
+
+      const result = await service.delete(mockBoard.id, mockUser.id);
+
+      expect(result).toBe(true);
+      expect(prismaService.board.delete).toHaveBeenCalledWith({
+        where: { id: mockBoard.id },
+      });
+    });
+
+    it('should throw ForbiddenException if user is MEMBER', async () => {
+      mockPrismaService.board.findUnique.mockResolvedValue({
+        ...mockBoard,
+        members: [
+          {
+            id: 'member-1',
+            userId: mockUser.id,
+            role: Role.MEMBER,
+          },
+        ],
+      });
+
+      await expect(service.delete(mockBoard.id, mockUser.id)).rejects.toThrow(
+        ForbiddenException,
+      );
+      await expect(service.delete(mockBoard.id, mockUser.id)).rejects.toThrow(
+        'Only board administrators can delete boards',
+      );
+    });
+
+    it('should throw ForbiddenException if user is OBSERVER', async () => {
+      mockPrismaService.board.findUnique.mockResolvedValue({
+        ...mockBoard,
+        members: [
+          {
+            id: 'member-1',
+            userId: mockUser.id,
+            role: Role.OBSERVER,
+          },
+        ],
+      });
+
+      await expect(service.delete(mockBoard.id, mockUser.id)).rejects.toThrow(
+        ForbiddenException,
+      );
+      await expect(service.delete(mockBoard.id, mockUser.id)).rejects.toThrow(
+        'Only board administrators can delete boards',
+      );
+    });
+
+    it('should throw ForbiddenException if user is not a board member', async () => {
+      mockPrismaService.board.findUnique.mockResolvedValue({
+        ...mockBoard,
+        members: [],
+      });
+
+      await expect(service.delete(mockBoard.id, mockUser.id)).rejects.toThrow(
+        ForbiddenException,
+      );
+      await expect(service.delete(mockBoard.id, mockUser.id)).rejects.toThrow(
+        'You are not a member of this board',
+      );
+    });
+  });
+
+  describe('archive', () => {
+    it('should archive board', async () => {
+      mockPrismaService.board.findUnique.mockResolvedValue(mockBoard);
+      mockPrismaService.board.update.mockResolvedValue({
+        ...mockBoard,
+        isArchived: true,
+      });
+
+      const result = await service.archive(mockBoard.id, mockUser.id);
+
+      expect(result.isArchived).toBe(true);
+      expect(prismaService.board.update).toHaveBeenCalledWith({
+        where: { id: mockBoard.id },
+        data: { isArchived: true },
+      });
+    });
+
+    it('should throw NotFoundException if board not found', async () => {
+      mockPrismaService.board.findUnique.mockResolvedValue(null);
+
+      await expect(service.archive('invalid-id', mockUser.id)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('unarchive', () => {
+    it('should unarchive board', async () => {
+      mockPrismaService.board.findUnique.mockResolvedValue({
+        ...mockBoard,
+        isArchived: true,
+      });
+      mockPrismaService.board.update.mockResolvedValue({
+        ...mockBoard,
+        isArchived: false,
+      });
+
+      const result = await service.unarchive(mockBoard.id, mockUser.id);
+
+      expect(result.isArchived).toBe(false);
+      expect(prismaService.board.update).toHaveBeenCalledWith({
+        where: { id: mockBoard.id },
+        data: { isArchived: false },
+      });
+    });
+  });
+
+  describe('addMember', () => {
+    it('should add a member to board if requester is ADMIN', async () => {
+      const input = {
+        boardId: mockBoard.id,
+        userId: 'user-2',
+        role: Role.MEMBER,
+      };
+
+      const newUser = {
+        id: 'user-2',
+        email: 'newuser@example.com',
+        name: 'New User',
+        avatar: null,
+      };
+
+      mockPrismaService.board.findUnique.mockResolvedValue(mockBoard);
+      mockPrismaService.user.findUnique.mockResolvedValue(newUser);
+      mockPrismaService.boardMember.create.mockResolvedValue({
+        id: 'member-2',
+        boardId: input.boardId,
+        userId: input.userId,
+        role: input.role,
+        joinedAt: new Date(),
+        user: newUser,
+      });
+
+      const result = await service.addMember(input, mockUser.id);
+
+      expect(result.userId).toBe(input.userId);
+      expect(result.role).toBe(input.role);
+      expect(prismaService.boardMember.create).toHaveBeenCalled();
+    });
+
+    it('should throw ForbiddenException if requester is not ADMIN', async () => {
+      const input = {
+        boardId: mockBoard.id,
+        userId: 'user-2',
+      };
+
+      mockPrismaService.board.findUnique.mockResolvedValue({
+        ...mockBoard,
+        members: [
+          {
+            id: 'member-1',
+            userId: mockUser.id,
+            role: Role.MEMBER,
+          },
+        ],
+      });
+
+      await expect(service.addMember(input, mockUser.id)).rejects.toThrow(ForbiddenException);
+      await expect(service.addMember(input, mockUser.id)).rejects.toThrow(
+        'Only board administrators can add members',
+      );
+    });
+
+    it('should throw ConflictException if user is already a member', async () => {
+      const input = {
+        boardId: mockBoard.id,
+        userId: 'user-2',
+      };
+
+      mockPrismaService.board.findUnique.mockResolvedValue({
+        ...mockBoard,
+        members: [
+          ...mockBoard.members,
+          {
+            id: 'member-2',
+            userId: 'user-2',
+            role: Role.MEMBER,
+          },
+        ],
+      });
+
+      await expect(service.addMember(input, mockUser.id)).rejects.toThrow(ConflictException);
+      await expect(service.addMember(input, mockUser.id)).rejects.toThrow(
+        'already a member',
+      );
+    });
+  });
+
+  describe('removeMember', () => {
+    it('should remove a member if requester is ADMIN', async () => {
+      const memberToRemove = {
+        id: 'member-2',
+        userId: 'user-2',
+        role: Role.MEMBER,
+      };
+
+      mockPrismaService.board.findUnique.mockResolvedValue({
+        ...mockBoard,
+        members: [
+          ...mockBoard.members,
+          memberToRemove,
+        ],
+      });
+      mockPrismaService.boardMember.delete.mockResolvedValue(memberToRemove);
+
+      const result = await service.removeMember(mockBoard.id, 'user-2', mockUser.id);
+
+      expect(result).toBe(true);
+      expect(prismaService.boardMember.delete).toHaveBeenCalled();
+    });
+
+    it('should throw ForbiddenException if requester is not ADMIN', async () => {
+      mockPrismaService.board.findUnique.mockResolvedValue({
+        ...mockBoard,
+        members: [
+          {
+            id: 'member-1',
+            userId: mockUser.id,
+            role: Role.MEMBER,
+          },
+        ],
+      });
+
+      await expect(service.removeMember(mockBoard.id, 'user-2', mockUser.id)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('should throw ForbiddenException if trying to remove last ADMIN', async () => {
+      mockPrismaService.board.findUnique.mockResolvedValue({
+        ...mockBoard,
+        members: [
+          {
+            id: 'member-1',
+            userId: mockUser.id,
+            role: Role.ADMIN,
+          },
+        ],
+      });
+
+      await expect(service.removeMember(mockBoard.id, mockUser.id, mockUser.id)).rejects.toThrow(
+        ForbiddenException,
+      );
+      await expect(service.removeMember(mockBoard.id, mockUser.id, mockUser.id)).rejects.toThrow(
+        'Cannot remove the last administrator',
+      );
+    });
+  });
+
+  describe('updateMemberRole', () => {
+    it('should update member role if requester is ADMIN', async () => {
+      const memberToUpdate = {
+        id: 'member-2',
+        userId: 'user-2',
+        role: Role.MEMBER,
+      };
+
+      mockPrismaService.board.findUnique.mockResolvedValue({
+        ...mockBoard,
+        members: [
+          ...mockBoard.members,
+          memberToUpdate,
+        ],
+      });
+      mockPrismaService.boardMember.update.mockResolvedValue({
+        ...memberToUpdate,
+        role: Role.ADMIN,
+      });
+
+      const result = await service.updateMemberRole(
+        mockBoard.id,
+        'user-2',
+        Role.ADMIN,
+        mockUser.id,
+      );
+
+      expect(result).toBe(true);
+      expect(prismaService.boardMember.update).toHaveBeenCalled();
+    });
+
+    it('should throw ForbiddenException if trying to change last ADMIN role', async () => {
+      mockPrismaService.board.findUnique.mockResolvedValue({
+        ...mockBoard,
+        members: [
+          {
+            id: 'member-1',
+            userId: mockUser.id,
+            role: Role.ADMIN,
+          },
+        ],
+      });
+
+      await expect(
+        service.updateMemberRole(mockBoard.id, mockUser.id, Role.MEMBER, mockUser.id),
+      ).rejects.toThrow(ForbiddenException);
+      await expect(
+        service.updateMemberRole(mockBoard.id, mockUser.id, Role.MEMBER, mockUser.id),
+      ).rejects.toThrow('Cannot change the last administrator role');
+    });
+  });
+});

--- a/backend/src/modules/boards/boards.service.ts
+++ b/backend/src/modules/boards/boards.service.ts
@@ -1,0 +1,473 @@
+import { Injectable, NotFoundException, ForbiddenException, ConflictException } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CreateBoardInput } from './dto/create-board.input';
+import { UpdateBoardInput } from './dto/update-board.input';
+import { AddBoardMemberInput } from './dto/add-board-member.input';
+import { Board } from './entities/board.entity';
+import { BoardMemberWithUser } from './entities/board-member.entity';
+import { Role } from '@prisma/client';
+
+@Injectable()
+export class BoardsService {
+  constructor(private prisma: PrismaService) {}
+
+  /**
+   * Create a new board
+   * - User must be ADMIN or MEMBER of the workspace (if workspaceId provided)
+   * - User becomes the creator and gets ADMIN role on the board
+   */
+  async create(input: CreateBoardInput, userId: string): Promise<Board> {
+    // If workspaceId is provided, verify user has permission in that workspace
+    if (input.workspaceId) {
+      const membership = await this.prisma.workspaceMember.findUnique({
+        where: {
+          workspaceId_userId: {
+            workspaceId: input.workspaceId,
+            userId,
+          },
+        },
+      });
+
+      if (!membership) {
+        throw new ForbiddenException('You are not a member of this workspace');
+      }
+
+      // Only ADMIN and MEMBER can create boards (not OBSERVER)
+      if (membership.role === Role.OBSERVER) {
+        throw new ForbiddenException('Observers cannot create boards');
+      }
+
+      // Verify workspace exists
+      const workspace = await this.prisma.workspace.findUnique({
+        where: { id: input.workspaceId },
+      });
+
+      if (!workspace) {
+        throw new NotFoundException('Workspace not found');
+      }
+    }
+
+    // Create board with creator as ADMIN
+    const board = await this.prisma.board.create({
+      data: {
+        title: input.title,
+        description: input.description,
+        workspaceId: input.workspaceId,
+        visibility: input.visibility || 'PRIVATE',
+        background: input.background,
+        creatorId: userId,
+        members: {
+          create: {
+            userId,
+            role: Role.ADMIN,
+          },
+        },
+      },
+    });
+
+    return board;
+  }
+
+  /**
+   * Find board by ID
+   * - User must be a member of the board OR workspace
+   * - Public boards can be viewed by anyone
+   */
+  async findOne(id: string, userId: string): Promise<Board> {
+    const board = await this.prisma.board.findUnique({
+      where: { id },
+      include: {
+        members: {
+          include: {
+            user: {
+              select: {
+                id: true,
+                email: true,
+                name: true,
+                avatar: true,
+              },
+            },
+          },
+        },
+        workspace: {
+          include: {
+            memberships: true,
+          },
+        },
+      },
+    });
+
+    if (!board) {
+      throw new NotFoundException('Board not found');
+    }
+
+    // Check access permissions
+    await this.checkBoardAccess(board, userId);
+
+    return board;
+  }
+
+  /**
+   * Find all boards in a workspace
+   * - User must be a member of the workspace
+   */
+  async findByWorkspace(workspaceId: string, userId: string): Promise<Board[]> {
+    // Verify user is member of workspace
+    const membership = await this.prisma.workspaceMember.findUnique({
+      where: {
+        workspaceId_userId: {
+          workspaceId,
+          userId,
+        },
+      },
+    });
+
+    if (!membership) {
+      throw new ForbiddenException('You are not a member of this workspace');
+    }
+
+    return this.prisma.board.findMany({
+      where: {
+        workspaceId,
+        isArchived: false,
+      },
+      include: {
+        members: {
+          include: {
+            user: {
+              select: {
+                id: true,
+                email: true,
+                name: true,
+                avatar: true,
+              },
+            },
+          },
+        },
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
+  }
+
+  /**
+   * Update a board
+   * - User must be ADMIN or MEMBER of the board (not OBSERVER)
+   */
+  async update(input: UpdateBoardInput, userId: string): Promise<Board> {
+    const board = await this.prisma.board.findUnique({
+      where: { id: input.id },
+      include: { members: true },
+    });
+
+    if (!board) {
+      throw new NotFoundException('Board not found');
+    }
+
+    // Check if user has edit permission
+    await this.checkBoardEditPermission(board, userId);
+
+    return this.prisma.board.update({
+      where: { id: input.id },
+      data: {
+        title: input.title,
+        description: input.description,
+        visibility: input.visibility,
+        background: input.background,
+      },
+    });
+  }
+
+  /**
+   * Delete a board
+   * - Only ADMIN of the board can delete
+   * - MEMBER and OBSERVER cannot delete
+   */
+  async delete(id: string, userId: string): Promise<boolean> {
+    const board = await this.prisma.board.findUnique({
+      where: { id },
+      include: { members: true },
+    });
+
+    if (!board) {
+      throw new NotFoundException('Board not found');
+    }
+
+    const membership = board.members.find((m) => m.userId === userId);
+
+    if (!membership) {
+      throw new ForbiddenException('You are not a member of this board');
+    }
+
+    if (membership.role !== Role.ADMIN) {
+      throw new ForbiddenException('Only board administrators can delete boards');
+    }
+
+    await this.prisma.board.delete({
+      where: { id },
+    });
+
+    return true;
+  }
+
+  /**
+   * Archive a board
+   * - User must be ADMIN or MEMBER of the board
+   */
+  async archive(id: string, userId: string): Promise<Board> {
+    const board = await this.prisma.board.findUnique({
+      where: { id },
+      include: { members: true },
+    });
+
+    if (!board) {
+      throw new NotFoundException('Board not found');
+    }
+
+    await this.checkBoardEditPermission(board, userId);
+
+    return this.prisma.board.update({
+      where: { id },
+      data: { isArchived: true },
+    });
+  }
+
+  /**
+   * Unarchive a board
+   * - User must be ADMIN or MEMBER of the board
+   */
+  async unarchive(id: string, userId: string): Promise<Board> {
+    const board = await this.prisma.board.findUnique({
+      where: { id },
+      include: { members: true },
+    });
+
+    if (!board) {
+      throw new NotFoundException('Board not found');
+    }
+
+    await this.checkBoardEditPermission(board, userId);
+
+    return this.prisma.board.update({
+      where: { id },
+      data: { isArchived: false },
+    });
+  }
+
+  /**
+   * Check if user has access to view the board
+   */
+  private async checkBoardAccess(board: any, userId: string): Promise<void> {
+    // Public boards are accessible to everyone
+    if (board.visibility === 'PUBLIC') {
+      return;
+    }
+
+    // Check if user is a board member
+    const isBoardMember = board.members.some((m: any) => m.userId === userId);
+    if (isBoardMember) {
+      return;
+    }
+
+    // Check if user is a workspace member (for WORKSPACE visibility)
+    if (board.workspaceId && board.workspace) {
+      const isWorkspaceMember = board.workspace.memberships.some(
+        (m: any) => m.userId === userId,
+      );
+      if (isWorkspaceMember) {
+        return;
+      }
+    }
+
+    throw new ForbiddenException('You do not have access to this board');
+  }
+
+  /**
+   * Add a member to a board
+   * - Only ADMIN can add members
+   */
+  async addMember(input: AddBoardMemberInput, userId: string): Promise<BoardMemberWithUser> {
+    const board = await this.prisma.board.findUnique({
+      where: { id: input.boardId },
+      include: { members: true },
+    });
+
+    if (!board) {
+      throw new NotFoundException('Board not found');
+    }
+
+    // Only ADMIN can add members
+    const requesterMembership = board.members.find((m) => m.userId === userId);
+    if (!requesterMembership || requesterMembership.role !== Role.ADMIN) {
+      throw new ForbiddenException('Only board administrators can add members');
+    }
+
+    // Check if user exists
+    const user = await this.prisma.user.findUnique({
+      where: { id: input.userId },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        avatar: true,
+      },
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    // Check if user is already a member
+    const existingMember = board.members.find((m) => m.userId === input.userId);
+    if (existingMember) {
+      throw new ConflictException('User is already a member of this board');
+    }
+
+    // Add member to board
+    const member = await this.prisma.boardMember.create({
+      data: {
+        boardId: input.boardId,
+        userId: input.userId,
+        role: input.role || Role.MEMBER,
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            email: true,
+            name: true,
+            avatar: true,
+          },
+        },
+      },
+    });
+
+    return {
+      id: member.id,
+      boardId: member.boardId,
+      userId: member.userId,
+      role: member.role,
+      joinedAt: member.joinedAt,
+      user: {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        avatar: user.avatar,
+      },
+    };
+  }
+
+  /**
+   * Remove a member from a board
+   * - Only ADMIN can remove members
+   * - Cannot remove the last ADMIN
+   */
+  async removeMember(boardId: string, memberUserId: string, requesterUserId: string): Promise<boolean> {
+    const board = await this.prisma.board.findUnique({
+      where: { id: boardId },
+      include: { members: true },
+    });
+
+    if (!board) {
+      throw new NotFoundException('Board not found');
+    }
+
+    // Only ADMIN can remove members
+    const requesterMembership = board.members.find((m) => m.userId === requesterUserId);
+    if (!requesterMembership || requesterMembership.role !== Role.ADMIN) {
+      throw new ForbiddenException('Only board administrators can remove members');
+    }
+
+    // Check if member exists
+    const memberToRemove = board.members.find((m) => m.userId === memberUserId);
+    if (!memberToRemove) {
+      throw new NotFoundException('Member not found in this board');
+    }
+
+    // Cannot remove the last ADMIN
+    const adminCount = board.members.filter((m) => m.role === Role.ADMIN).length;
+    if (memberToRemove.role === Role.ADMIN && adminCount === 1) {
+      throw new ForbiddenException('Cannot remove the last administrator. Assign another admin first.');
+    }
+
+    await this.prisma.boardMember.delete({
+      where: {
+        boardId_userId: {
+          boardId,
+          userId: memberUserId,
+        },
+      },
+    });
+
+    return true;
+  }
+
+  /**
+   * Update a member's role in a board
+   * - Only ADMIN can update roles
+   * - Cannot remove the last ADMIN
+   */
+  async updateMemberRole(
+    boardId: string,
+    memberUserId: string,
+    newRole: Role,
+    requesterUserId: string,
+  ): Promise<boolean> {
+    const board = await this.prisma.board.findUnique({
+      where: { id: boardId },
+      include: { members: true },
+    });
+
+    if (!board) {
+      throw new NotFoundException('Board not found');
+    }
+
+    // Only ADMIN can update roles
+    const requesterMembership = board.members.find((m) => m.userId === requesterUserId);
+    if (!requesterMembership || requesterMembership.role !== Role.ADMIN) {
+      throw new ForbiddenException('Only board administrators can update member roles');
+    }
+
+    // Check if member exists
+    const memberToUpdate = board.members.find((m) => m.userId === memberUserId);
+    if (!memberToUpdate) {
+      throw new NotFoundException('Member not found in this board');
+    }
+
+    // Cannot change the last ADMIN to another role
+    const adminCount = board.members.filter((m) => m.role === Role.ADMIN).length;
+    if (memberToUpdate.role === Role.ADMIN && adminCount === 1 && newRole !== Role.ADMIN) {
+      throw new ForbiddenException('Cannot change the last administrator role. Assign another admin first.');
+    }
+
+    await this.prisma.boardMember.update({
+      where: {
+        boardId_userId: {
+          boardId,
+          userId: memberUserId,
+        },
+      },
+      data: { role: newRole },
+    });
+
+    return true;
+  }
+
+  /**
+   * Check if user has permission to edit the board
+   * - ADMIN and MEMBER can edit
+   * - OBSERVER can only view
+   */
+  private async checkBoardEditPermission(board: any, userId: string): Promise<void> {
+    const membership = board.members.find((m: any) => m.userId === userId);
+
+    if (!membership) {
+      throw new ForbiddenException('You are not a member of this board');
+    }
+
+    if (membership.role === Role.OBSERVER) {
+      throw new ForbiddenException('Observers do not have edit permission');
+    }
+  }
+}

--- a/backend/src/modules/boards/dto/add-board-member.input.ts
+++ b/backend/src/modules/boards/dto/add-board-member.input.ts
@@ -1,0 +1,20 @@
+import { InputType, Field, ID } from '@nestjs/graphql';
+import { IsNotEmpty, IsEnum, IsUUID } from 'class-validator';
+import { Role } from '@prisma/client';
+
+@InputType()
+export class AddBoardMemberInput {
+  @Field(() => ID)
+  @IsNotEmpty()
+  @IsUUID()
+  boardId: string;
+
+  @Field(() => ID)
+  @IsNotEmpty()
+  @IsUUID()
+  userId: string;
+
+  @Field(() => String, { nullable: true })
+  @IsEnum(Role)
+  role?: Role;
+}

--- a/backend/src/modules/boards/dto/create-board.input.ts
+++ b/backend/src/modules/boards/dto/create-board.input.ts
@@ -1,0 +1,31 @@
+import { InputType, Field, ID } from '@nestjs/graphql';
+import { IsNotEmpty, IsString, IsOptional, IsEnum, IsUUID } from 'class-validator';
+import { Visibility } from '@prisma/client';
+
+@InputType()
+export class CreateBoardInput {
+  @Field()
+  @IsNotEmpty()
+  @IsString()
+  title: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @Field(() => ID, { nullable: true })
+  @IsOptional()
+  @IsUUID()
+  workspaceId?: string;
+
+  @Field(() => Visibility, { nullable: true })
+  @IsOptional()
+  @IsEnum(Visibility)
+  visibility?: Visibility;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsString()
+  background?: string;
+}

--- a/backend/src/modules/boards/dto/update-board-member-role.input.ts
+++ b/backend/src/modules/boards/dto/update-board-member-role.input.ts
@@ -1,0 +1,21 @@
+import { InputType, Field, ID } from '@nestjs/graphql';
+import { IsNotEmpty, IsEnum, IsUUID } from 'class-validator';
+import { Role } from '@prisma/client';
+
+@InputType()
+export class UpdateBoardMemberRoleInput {
+  @Field(() => ID)
+  @IsNotEmpty()
+  @IsUUID()
+  boardId: string;
+
+  @Field(() => ID)
+  @IsNotEmpty()
+  @IsUUID()
+  userId: string;
+
+  @Field(() => String)
+  @IsNotEmpty()
+  @IsEnum(Role)
+  role: Role;
+}

--- a/backend/src/modules/boards/dto/update-board.input.ts
+++ b/backend/src/modules/boards/dto/update-board.input.ts
@@ -1,0 +1,31 @@
+import { InputType, Field, ID } from '@nestjs/graphql';
+import { IsNotEmpty, IsString, IsOptional, IsEnum, IsUUID } from 'class-validator';
+import { Visibility } from '@prisma/client';
+
+@InputType()
+export class UpdateBoardInput {
+  @Field(() => ID)
+  @IsNotEmpty()
+  @IsUUID()
+  id: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @Field(() => Visibility, { nullable: true })
+  @IsOptional()
+  @IsEnum(Visibility)
+  visibility?: Visibility;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsString()
+  background?: string;
+}

--- a/backend/src/modules/boards/entities/board-member.entity.ts
+++ b/backend/src/modules/boards/entities/board-member.entity.ts
@@ -1,0 +1,41 @@
+import { ObjectType, Field, ID } from '@nestjs/graphql';
+import { MemberUser } from '../../invitations/entities/workspace-member.entity';
+
+@ObjectType()
+export class BoardMember {
+  @Field(() => ID)
+  id: string;
+
+  @Field(() => ID)
+  boardId: string;
+
+  @Field(() => ID)
+  userId: string;
+
+  @Field()
+  role: string;
+
+  @Field()
+  joinedAt: Date;
+}
+
+@ObjectType()
+export class BoardMemberWithUser {
+  @Field(() => ID)
+  id: string;
+
+  @Field(() => ID)
+  boardId: string;
+
+  @Field(() => ID)
+  userId: string;
+
+  @Field()
+  role: string;
+
+  @Field()
+  joinedAt: Date;
+
+  @Field(() => MemberUser)
+  user: MemberUser;
+}

--- a/backend/src/modules/boards/entities/board.entity.ts
+++ b/backend/src/modules/boards/entities/board.entity.ts
@@ -1,0 +1,45 @@
+import { ObjectType, Field, ID, registerEnumType } from '@nestjs/graphql';
+import { Visibility } from '@prisma/client';
+import { BoardMemberWithUser } from './board-member.entity';
+
+// Register the Visibility enum for GraphQL
+registerEnumType(Visibility, {
+  name: 'Visibility',
+  description: 'Board visibility settings',
+});
+
+@ObjectType()
+export class Board {
+  @Field(() => ID)
+  id: string;
+
+  @Field(() => ID, { nullable: true })
+  workspaceId?: string;
+
+  @Field()
+  title: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field(() => Visibility)
+  visibility: Visibility;
+
+  @Field({ nullable: true })
+  background?: string;
+
+  @Field()
+  isArchived: boolean;
+
+  @Field(() => ID)
+  creatorId: string;
+
+  @Field(() => [BoardMemberWithUser], { nullable: true })
+  members?: BoardMemberWithUser[];
+
+  @Field()
+  createdAt: Date;
+
+  @Field()
+  updatedAt: Date;
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -1913,15 +1913,809 @@ Cancel a pending invitation. Only the inviter or workspace admin can cancel.
 
 ---
 
+---
+
+## Boards
+
+### Create Board
+
+Create a new board within a workspace or as a personal board.
+
+**Mutation**: `createBoard`
+
+**Permissions**: User must be ADMIN or MEMBER of the workspace (OBSERVER cannot create boards)
+
+**GraphQL Query**:
+
+```graphql
+mutation CreateBoard($input: CreateBoardInput!) {
+  createBoard(input: $input) {
+    id
+    title
+    description
+    workspaceId
+    visibility
+    background
+    isArchived
+    creatorId
+    members {
+      id
+      userId
+      role
+      joinedAt
+      user {
+        id
+        email
+        name
+        avatar
+      }
+    }
+    createdAt
+    updatedAt
+  }
+}
+```
+
+**Variables**:
+
+```json
+{
+  "input": {
+    "title": "Sprint Planning Q1 2024",
+    "description": "Planning board for Q1 sprint",
+    "workspaceId": "workspace-uuid",
+    "visibility": "WORKSPACE",
+    "background": "#0079BF"
+  }
+}
+```
+
+> **Note**: All fields except `title` are optional
+
+**Response**:
+
+```json
+{
+  "data": {
+    "createBoard": {
+      "id": "board-uuid",
+      "title": "Sprint Planning Q1 2024",
+      "description": "Planning board for Q1 sprint",
+      "workspaceId": "workspace-uuid",
+      "visibility": "WORKSPACE",
+      "background": "#0079BF",
+      "isArchived": false,
+      "creatorId": "user-uuid",
+      "members": [
+        {
+          "id": "member-uuid",
+          "userId": "user-uuid",
+          "role": "ADMIN",
+          "joinedAt": "2024-01-01T00:00:00.000Z",
+          "user": {
+            "id": "user-uuid",
+            "email": "creator@example.com",
+            "name": "Creator User",
+            "avatar": null
+          }
+        }
+      ],
+      "createdAt": "2024-01-01T00:00:00.000Z",
+      "updatedAt": "2024-01-01T00:00:00.000Z"
+    }
+  }
+}
+```
+
+**Notes**:
+
+- Creator automatically becomes ADMIN of the board
+- If `workspaceId` is not provided, creates a personal board
+- Default visibility is `PRIVATE`
+- OBSERVER role cannot create boards
+
+**Error Cases**:
+
+- `403 Forbidden` - User is not a member of the workspace
+- `403 Forbidden` - User is an OBSERVER (cannot create boards)
+- `404 Not Found` - Workspace not found
+
+---
+
+### Get Board by ID
+
+Get a specific board by ID.
+
+**Query**: `board`
+
+**Permissions**: Based on board visibility
+
+- **PUBLIC**: Anyone can view
+- **WORKSPACE**: Workspace members can view
+- **PRIVATE**: Only board members can view
+
+**GraphQL Query**:
+
+```graphql
+query Board($id: ID!) {
+  board(id: $id) {
+    id
+    title
+    description
+    workspaceId
+    visibility
+    background
+    isArchived
+    creatorId
+    members {
+      id
+      userId
+      role
+      joinedAt
+      user {
+        id
+        email
+        name
+        avatar
+      }
+    }
+    createdAt
+    updatedAt
+  }
+}
+```
+
+**Variables**:
+
+```json
+{
+  "id": "board-uuid"
+}
+```
+
+**cURL Example**:
+
+```bash
+curl -X POST http://localhost:4000/graphql \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN" \
+  -d '{
+    "query": "query Board($id: ID!) { board(id: $id) { id title visibility isArchived members { id userId role user { id email name } } } }",
+    "variables": {
+      "id": "board-uuid"
+    }
+  }'
+```
+
+**Error Cases**:
+
+- `404 Not Found` - Board does not exist
+- `403 Forbidden` - User does not have access to this board
+
+---
+
+### List Workspace Boards
+
+Get all non-archived boards in a workspace.
+
+**Query**: `workspaceBoards`
+
+**Permissions**: User must be a member of the workspace
+
+**GraphQL Query**:
+
+```graphql
+query WorkspaceBoards($workspaceId: ID!) {
+  workspaceBoards(workspaceId: $workspaceId) {
+    id
+    title
+    description
+    visibility
+    background
+    isArchived
+    creatorId
+    members {
+      id
+      userId
+      role
+      joinedAt
+      user {
+        id
+        email
+        name
+        avatar
+      }
+    }
+    createdAt
+  }
+}
+```
+
+**Variables**:
+
+```json
+{
+  "workspaceId": "workspace-uuid"
+}
+```
+
+**Response**:
+
+```json
+{
+  "data": {
+    "workspaceBoards": [
+      {
+        "id": "board-uuid-1",
+        "title": "Sprint Planning",
+        "description": "Q1 2024",
+        "visibility": "WORKSPACE",
+        "background": "#0079BF",
+        "isArchived": false,
+        "creatorId": "user-uuid",
+        "members": [
+          {
+            "id": "member-uuid-1",
+            "userId": "user-uuid",
+            "role": "ADMIN",
+            "joinedAt": "2024-01-01T00:00:00.000Z",
+            "user": {
+              "id": "user-uuid",
+              "email": "creator@example.com",
+              "name": "Creator User",
+              "avatar": null
+            }
+          }
+        ],
+        "createdAt": "2024-01-01T00:00:00.000Z"
+      }
+    ]
+  }
+}
+```
+
+**Notes**:
+
+- Only returns non-archived boards
+- Results ordered by creation date (newest first)
+- Requires workspace membership
+
+**Error Cases**:
+
+- `403 Forbidden` - User is not a member of the workspace
+
+---
+
+### Update Board
+
+Update board properties.
+
+**Mutation**: `updateBoard`
+
+**Permissions**: User must be ADMIN or MEMBER of the board (OBSERVER cannot edit)
+
+**GraphQL Query**:
+
+```graphql
+mutation UpdateBoard($input: UpdateBoardInput!) {
+  updateBoard(input: $input) {
+    id
+    title
+    description
+    visibility
+    background
+    members {
+      id
+      userId
+      role
+      user {
+        id
+        email
+        name
+      }
+    }
+    updatedAt
+  }
+}
+```
+
+**Variables**:
+
+```json
+{
+  "input": {
+    "id": "board-uuid",
+    "title": "Updated Sprint Planning",
+    "description": "Q1 2024 - Updated",
+    "visibility": "PUBLIC",
+    "background": "#00C2E0"
+  }
+}
+```
+
+> **Note**: All fields except `id` are optional
+
+**cURL Example**:
+
+```bash
+curl -X POST http://localhost:4000/graphql \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN" \
+  -d '{
+    "query": "mutation UpdateBoard($input: UpdateBoardInput!) { updateBoard(input: $input) { id title visibility } }",
+    "variables": {
+      "input": {
+        "id": "board-uuid",
+        "title": "Updated Title"
+      }
+    }
+  }'
+```
+
+**Error Cases**:
+
+- `404 Not Found` - Board does not exist
+- `403 Forbidden` - User is not a member of the board
+- `403 Forbidden` - User is an OBSERVER (cannot edit)
+
+---
+
+### Delete Board
+
+Permanently delete a board.
+
+**Mutation**: `deleteBoard`
+
+**Permissions**: Only board ADMIN can delete
+
+**GraphQL Query**:
+
+```graphql
+mutation DeleteBoard($id: ID!) {
+  deleteBoard(id: $id)
+}
+```
+
+**Variables**:
+
+```json
+{
+  "id": "board-uuid"
+}
+```
+
+**Response**:
+
+```json
+{
+  "data": {
+    "deleteBoard": true
+  }
+}
+```
+
+**Notes**:
+
+- Permanently deletes the board and all associated data (lists, cards, comments, etc.)
+- This action is irreversible
+- Only ADMIN role can delete boards
+
+**Error Cases**:
+
+- `404 Not Found` - Board does not exist
+- `403 Forbidden` - User is not an ADMIN of the board
+
+---
+
+### Archive Board
+
+Archive a board (soft delete).
+
+**Mutation**: `archiveBoard`
+
+**Permissions**: User must be ADMIN or MEMBER of the board
+
+**GraphQL Query**:
+
+```graphql
+mutation ArchiveBoard($id: ID!) {
+  archiveBoard(id: $id) {
+    id
+    title
+    isArchived
+    members {
+      id
+      userId
+      role
+      user {
+        id
+        email
+        name
+      }
+    }
+    updatedAt
+  }
+}
+```
+
+**Variables**:
+
+```json
+{
+  "id": "board-uuid"
+}
+```
+
+**Response**:
+
+```json
+{
+  "data": {
+    "archiveBoard": {
+      "id": "board-uuid",
+      "title": "Sprint Planning",
+      "isArchived": true,
+      "updatedAt": "2024-01-10T00:00:00.000Z"
+    }
+  }
+}
+```
+
+**Notes**:
+
+- Archived boards are hidden from workspace board lists
+- Board data is preserved and can be unarchived
+- OBSERVER cannot archive boards
+
+**Error Cases**:
+
+- `404 Not Found` - Board does not exist
+- `403 Forbidden` - User does not have edit permission
+
+---
+
+### Unarchive Board
+
+Restore an archived board.
+
+**Mutation**: `unarchiveBoard`
+
+**Permissions**: User must be ADMIN or MEMBER of the board
+
+**GraphQL Query**:
+
+```graphql
+mutation UnarchiveBoard($id: ID!) {
+  unarchiveBoard(id: $id) {
+    id
+    title
+    isArchived
+    members {
+      id
+      userId
+      role
+      user {
+        id
+        email
+        name
+      }
+    }
+    updatedAt
+  }
+}
+```
+
+**Variables**:
+
+```json
+{
+  "id": "board-uuid"
+}
+```
+
+**Response**:
+
+```json
+{
+  "data": {
+    "unarchiveBoard": {
+      "id": "board-uuid",
+      "title": "Sprint Planning",
+      "isArchived": false,
+      "updatedAt": "2024-01-15T00:00:00.000Z"
+    }
+  }
+}
+```
+
+**Error Cases**:
+
+- `404 Not Found` - Board does not exist
+- `403 Forbidden` - User does not have edit permission
+
+---
+
+### Add Board Member
+
+Add a member to a board.
+
+**Mutation**: `addBoardMember`
+
+**Permissions**: Only board ADMIN can add members
+
+**GraphQL Query**:
+
+```graphql
+mutation AddBoardMember($input: AddBoardMemberInput!) {
+  addBoardMember(input: $input) {
+    id
+    boardId
+    userId
+    role
+    joinedAt
+    user {
+      id
+      email
+      name
+      avatar
+    }
+  }
+}
+```
+
+**Variables**:
+
+```json
+{
+  "input": {
+    "boardId": "board-uuid",
+    "userId": "user-uuid",
+    "role": "MEMBER"
+  }
+}
+```
+
+> **Note**: `role` is optional, defaults to `MEMBER`. Available roles: `ADMIN`, `MEMBER`, `OBSERVER`
+
+**Response**:
+
+```json
+{
+  "data": {
+    "addBoardMember": {
+      "id": "member-uuid",
+      "boardId": "board-uuid",
+      "userId": "user-uuid",
+      "role": "MEMBER",
+      "joinedAt": "2024-01-01T00:00:00.000Z",
+      "user": {
+        "id": "user-uuid",
+        "email": "user@example.com",
+        "name": "John Doe",
+        "avatar": "https://example.com/avatar.jpg"
+      }
+    }
+  }
+}
+```
+
+**cURL Example**:
+
+```bash
+curl -X POST http://localhost:4000/graphql \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN" \
+  -d '{
+    "query": "mutation AddBoardMember($input: AddBoardMemberInput!) { addBoardMember(input: $input) { id userId role user { id email name } } }",
+    "variables": {
+      "input": {
+        "boardId": "board-uuid",
+        "userId": "user-uuid",
+        "role": "MEMBER"
+      }
+    }
+  }'
+```
+
+**Error Cases**:
+
+- `403 Forbidden` - User is not an ADMIN of the board
+- `404 Not Found` - Board or user not found
+- `409 Conflict` - User is already a member of the board
+
+---
+
+### Remove Board Member
+
+Remove a member from a board.
+
+**Mutation**: `removeBoardMember`
+
+**Permissions**: Only board ADMIN can remove members
+
+**GraphQL Query**:
+
+```graphql
+mutation RemoveBoardMember($boardId: ID!, $userId: ID!) {
+  removeBoardMember(boardId: $boardId, userId: $userId)
+}
+```
+
+**Variables**:
+
+```json
+{
+  "boardId": "board-uuid",
+  "userId": "user-uuid"
+}
+```
+
+**Response**:
+
+```json
+{
+  "data": {
+    "removeBoardMember": true
+  }
+}
+```
+
+**Notes**:
+
+- Cannot remove the last ADMIN (must assign another admin first)
+- Removed member loses all access to the board
+
+**Error Cases**:
+
+- `403 Forbidden` - User is not an ADMIN of the board
+- `404 Not Found` - Board or member not found
+- `403 Forbidden` - Cannot remove the last administrator
+
+---
+
+### Update Board Member Role
+
+Update a member's role in a board.
+
+**Mutation**: `updateBoardMemberRole`
+
+**Permissions**: Only board ADMIN can update roles
+
+**GraphQL Query**:
+
+```graphql
+mutation UpdateBoardMemberRole($input: UpdateBoardMemberRoleInput!) {
+  updateBoardMemberRole(input: $input)
+}
+```
+
+**Variables**:
+
+```json
+{
+  "input": {
+    "boardId": "board-uuid",
+    "userId": "user-uuid",
+    "role": "ADMIN"
+  }
+}
+```
+
+**Response**:
+
+```json
+{
+  "data": {
+    "updateBoardMemberRole": true
+  }
+}
+```
+
+**Notes**:
+
+- Cannot change the last ADMIN to another role
+- Available roles: `ADMIN`, `MEMBER`, `OBSERVER`
+
+**Error Cases**:
+
+- `403 Forbidden` - User is not an ADMIN of the board
+- `404 Not Found` - Board or member not found
+- `403 Forbidden` - Cannot change the last administrator role
+
+---
+
+## Board Types
+
+### Board
+
+```graphql
+type Board {
+  id: ID!
+  workspaceId: ID
+  title: String!
+  description: String
+  visibility: Visibility!
+  background: String
+  isArchived: Boolean!
+  creatorId: ID!
+  members: [BoardMemberWithUser!]
+  createdAt: DateTime!
+  updatedAt: DateTime!
+}
+```
+
+> **Note**: `members` field contains all board members with their user information and roles
+
+### CreateBoardInput
+
+```graphql
+input CreateBoardInput {
+  title: String!
+  description: String
+  workspaceId: ID
+  visibility: Visibility
+  background: String
+}
+```
+
+### UpdateBoardInput
+
+```graphql
+input UpdateBoardInput {
+  id: ID!
+  title: String
+  description: String
+  visibility: Visibility
+  background: String
+}
+```
+
+### AddBoardMemberInput
+
+```graphql
+input AddBoardMemberInput {
+  boardId: ID!
+  userId: ID!
+  role: String
+}
+```
+
+> **Note**: `role` is optional, defaults to `MEMBER`
+
+### UpdateBoardMemberRoleInput
+
+```graphql
+input UpdateBoardMemberRoleInput {
+  boardId: ID!
+  userId: ID!
+  role: String!
+}
+```
+
+### BoardMemberWithUser
+
+```graphql
+type BoardMemberWithUser {
+  id: ID!
+  boardId: ID!
+  userId: ID!
+  role: String!
+  joinedAt: DateTime!
+  user: MemberUser!
+}
+```
+
+---
+
 ## Role-Based Access Control
 
 ### Roles
 
-- **ADMIN**: Full control over workspace (invite, remove, update roles, delete workspace)
-- **MEMBER**: Can view and edit workspace content
-- **OBSERVER**: Read-only access to workspace
+- **ADMIN**: Full control over workspace/board (invite, remove, update roles, delete)
+- **MEMBER**: Can view and edit content, create boards
+- **OBSERVER**: Read-only access (cannot create or edit)
 
-### Permission Matrix
+### Permission Matrix - Workspaces
 
 | Action           | ADMIN | MEMBER | OBSERVER |
 | ---------------- | ----- | ------ | -------- |
@@ -1931,9 +2725,144 @@ Cancel a pending invitation. Only the inviter or workspace admin can cancel.
 | Invite members   | ✓     | ✗      | ✗        |
 | Remove members   | ✓     | ✗      | ✗        |
 | Update roles     | ✓     | ✗      | ✗        |
+| Create boards    | ✓     | ✓      | ✗        |
 | Leave workspace  | ✓\*   | ✓      | ✓        |
 
 > **Note**: \*ADMINs cannot leave if they are the last admin. They must assign another admin first.
+
+### Permission Matrix - Boards
+
+| Action             | ADMIN | MEMBER | OBSERVER |
+| ------------------ | ----- | ------ | -------- |
+| View board         | ✓     | ✓      | ✓        |
+| Edit board         | ✓     | ✓      | ✗        |
+| Delete board       | ✓     | ✗      | ✗        |
+| Archive            | ✓     | ✓      | ✗        |
+| Unarchive          | ✓     | ✓      | ✗        |
+| Add members        | ✓     | ✗      | ✗        |
+| Remove members     | ✓     | ✗      | ✗        |
+| Update member role | ✓     | ✗      | ✗        |
+
+### Board Visibility
+
+- **PRIVATE**: Only board members can view
+- **WORKSPACE**: All workspace members can view
+- **PUBLIC**: Anyone can view (even without authentication)
+
+---
+
+## Board Management Examples
+
+### Complete Board Workflow with Members
+
+1. **Create a board:**
+
+```graphql
+mutation {
+  createBoard(
+    input: {
+      title: "Sprint Planning"
+      workspaceId: "workspace-uuid"
+      visibility: WORKSPACE
+    }
+  ) {
+    id
+    title
+    members {
+      id
+      userId
+      role
+      user {
+        id
+        email
+        name
+      }
+    }
+  }
+}
+```
+
+2. **Get board with all members:**
+
+```graphql
+query {
+  board(id: "board-uuid") {
+    id
+    title
+    visibility
+    members {
+      id
+      userId
+      role
+      joinedAt
+      user {
+        id
+        email
+        name
+        avatar
+      }
+    }
+  }
+}
+```
+
+3. **Add a member to the board:**
+
+```graphql
+mutation {
+  addBoardMember(
+    input: {
+      boardId: "board-uuid"
+      userId: "user-uuid-2"
+      role: MEMBER
+    }
+  ) {
+    id
+    userId
+    role
+    user {
+      id
+      email
+      name
+    }
+  }
+}
+```
+
+4. **Update a member's role:**
+
+```graphql
+mutation {
+  updateBoardMemberRole(
+    input: {
+      boardId: "board-uuid"
+      userId: "user-uuid-2"
+      role: ADMIN
+    }
+  )
+}
+```
+
+5. **List all boards in workspace with members:**
+
+```graphql
+query {
+  workspaceBoards(workspaceId: "workspace-uuid") {
+    id
+    title
+    members {
+      id
+      userId
+      role
+      user {
+        id
+        email
+        name
+      }
+    }
+  }
+}
+```
 
 ---
 


### PR DESCRIPTION
Create board mutation (createBoard)

Get board by ID query (board(id: ID!))

List workspace boards query (workspaceBoards(workspaceId: ID!))

Update board mutation (updateBoard)

Delete board mutation (deleteBoard)

Archive/unarchive board mutation (archiveBoard, unarchiveBoard)

Board visibility settings (private/workspace/public)

Permission checks (ADMIN/MEMBER can create, VIEWER read-only)

GraphQL resolvers implemented in NestJS

Unit tests coverage > 80%