### PR TITLE
feat: ajouter l'API Container Registry pour la compatibilité GCR

### DIFF
--- a/terraform/apis.tf
+++ b/terraform/apis.tf
@@ -6,6 +6,7 @@ locals {
     "sqladmin.googleapis.com",
     "storage-api.googleapis.com",
     "artifactregistry.googleapis.com",
+    "containerregistry.googleapis.com",
     "secretmanager.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "iam.googleapis.com",


### PR DESCRIPTION
- Ajouter containerregistry.googleapis.com à la liste des APIs requises
- Nécessaire pour le push d'images Docker vers gcr.io