### PR TITLE
feat: add createOnPushWriter role for automatic GCR repository creation

### DIFF
--- a/terraform/service-account.tf
+++ b/terraform/service-account.tf
@@ -15,6 +15,7 @@ locals {
     "roles/iam.serviceAccountUser",
     "roles/artifactregistry.admin",
     "roles/artifactregistry.writer",
+    "roles/artifactregistry.createOnPushWriter",
     "roles/secretmanager.admin",
     "roles/serviceusage.serviceUsageConsumer",
   ]


### PR DESCRIPTION
- Add roles/artifactregistry.createOnPushWriter to service account
- Enables automatic GCR repository creation on first Docker push
- Required permission: artifactregistry.repositories.createOnPush