### PR TITLE
fix: configure backend for Cloud Run port 8080 and add App Engine dep…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -484,11 +484,35 @@ jobs:
         env:
           NEXT_PUBLIC_API_URL: ${{ secrets.STAGING_API_URL || secrets.PRODUCTION_API_URL }}
 
+      - name: Get Backend URL
+        id: backend-url
+        run: |
+          ENV=${{ needs.detect-changes.outputs.environment }}
+          SERVICE_NAME="${ENV}-epitrello-backend"
+          URL=$(gcloud run services describe $SERVICE_NAME \
+            --region ${{ env.GCP_REGION }} \
+            --format="value(status.url)" 2>/dev/null || echo "")
+          if [ -z "$URL" ]; then
+            echo "ERROR: Could not retrieve backend URL for service: $SERVICE_NAME"
+            exit 1
+          fi
+          echo "Backend URL: $URL"
+          echo "url=$URL" >> $GITHUB_OUTPUT
+
       - name: Deploy to App Engine
         working-directory: frontend
         run: |
           ENV=${{ needs.detect-changes.outputs.environment }}
-          gcloud app deploy --version=${ENV}-${{ github.sha }} --no-promote
+          API_URL="${{ steps.backend-url.outputs.url }}"
+          if [ -z "$API_URL" ]; then
+            echo "ERROR: Backend URL is not set"
+            exit 1
+          fi
+          echo "Deploying frontend with API URL: $API_URL"
+          gcloud app deploy app.yaml \
+            --version=${ENV}-${{ github.sha }} \
+            --no-promote \
+            --set-env-vars="NEXT_PUBLIC_API_URL=${API_URL}"
 
   smoke-tests:
     name: Smoke Tests

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -43,6 +43,6 @@ COPY --from=builder /app/scripts ./scripts
 
 RUN chmod +x ./scripts/docker-entrypoint.sh
 
-EXPOSE 4000
+EXPOSE 8080
 
 ENTRYPOINT ["./scripts/docker-entrypoint.sh"]

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -13,6 +13,7 @@ import { InvitationsModule } from './modules/invitations/invitations.module';
 import { BoardsModule } from './modules/boards/boards.module';
 import { GqlAuthGuard } from './common/guards/gql-auth.guard';
 import { AllExceptionsFilter } from './common/filters/http-exception.filter';
+import { HealthController } from './common/controllers/health.controller';
 
 @Module({
   imports: [
@@ -50,6 +51,7 @@ import { AllExceptionsFilter } from './common/filters/http-exception.filter';
     InvitationsModule,
     BoardsModule,
   ],
+  controllers: [HealthController],
   providers: [
     {
       provide: APP_GUARD,

--- a/backend/src/common/controllers/health.controller.ts
+++ b/backend/src/common/controllers/health.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get } from '@nestjs/common';
+import { Public } from '../decorators/public.decorator';
+
+@Controller()
+export class HealthController {
+  @Get('health')
+  @Public()
+  health() {
+    return {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+    };
+  }
+}

--- a/backend/src/config/app.config.ts
+++ b/backend/src/config/app.config.ts
@@ -1,6 +1,6 @@
 export default () => ({
   app: {
-    port: parseInt(process.env.PORT, 10) || 4000,
+    port: parseInt(process.env.PORT, 10) || 8080,
     nodeEnv: process.env.NODE_ENV || 'development',
     frontendUrl: process.env.FRONTEND_URL || 'http://localhost:3000',
   },

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -29,7 +29,7 @@ async function bootstrap() {
   // production, restrict to configured frontends.
   const isProduction = process.env.NODE_ENV === 'production';
   const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
-  const backendPort = process.env.PORT || '4000';
+  const backendPort = process.env.PORT || '8080';
 
   const allowedOrigins = isProduction
     ? [frontendUrl, `http://localhost:${backendPort}`]
@@ -54,7 +54,7 @@ async function bootstrap() {
     }),
   );
 
-  const port = process.env.PORT || 4000;
+  const port = process.env.PORT || 8080;
   await app.listen(port);
 
   logger.log(`🚀 Application is running on: http://localhost:${port}/graphql`);

--- a/frontend/app.yaml
+++ b/frontend/app.yaml
@@ -1,0 +1,19 @@
+runtime: nodejs20
+
+env: standard
+
+instance_class: F2
+
+automatic_scaling:
+  min_instances: 0
+  max_instances: 10
+  target_cpu_utilization: 0.6
+  target_throughput_utilization: 0.6
+
+env_variables:
+  NODE_ENV: production
+
+handlers:
+  - url: /.*
+    script: auto
+    secure: always

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev --webpack",
     "build": "next build --webpack",
-    "start": "next start",
+    "start": "next start -p ${PORT:-8080}",
     "lint": "eslint"
   },
   "dependencies": {

--- a/terraform/modules/cloud-run/main.tf
+++ b/terraform/modules/cloud-run/main.tf
@@ -37,10 +37,10 @@ resource "google_cloud_run_v2_service" "backend" {
         startup_cpu_boost = false
       }
 
-      # Container port
+      # Container port (Cloud Run standard is 8080)
       ports {
         name           = "http1"
-        container_port = 4000
+        container_port = 8080
       }
 
       # ===================================
@@ -55,7 +55,7 @@ resource "google_cloud_run_v2_service" "backend" {
 
       env {
         name  = "PORT"
-        value = "4000"
+        value = "8080"
       }
 
       # Database connection (direct via public IP + SSL)
@@ -232,21 +232,21 @@ resource "google_cloud_run_v2_service" "backend" {
       startup_probe {
         http_get {
           path = "/health"
-          port = 4000
+          port = 8080
         }
-        initial_delay_seconds = 10
-        timeout_seconds       = 3
-        period_seconds        = 10
-        failure_threshold     = 3
+        initial_delay_seconds = 0
+        timeout_seconds       = 10
+        period_seconds        = 5
+        failure_threshold     = 6
       }
 
       liveness_probe {
         http_get {
           path = "/health"
-          port = 4000
+          port = 8080
         }
         initial_delay_seconds = 30
-        timeout_seconds       = 3
+        timeout_seconds       = 10
         period_seconds        = 30
         failure_threshold     = 3
       }


### PR DESCRIPTION
…loyment

- Change backend port from 4000 to 8080 (Cloud Run standard)
- Add /health endpoint for Cloud Run health checks
- Create app.yaml for App Engine frontend deployment
- Update frontend start script to use PORT environment variable
- Automatically retrieve backend URL from Cloud Run for frontend deployment
- Increase startup probe timeout for better reliability