### PR TITLE
fix: prevent subsequent jobs from running when a job fails

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -323,7 +323,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [detect-changes, terraform-plan]
-    if: github.event_name != 'pull_request' && needs.detect-changes.outputs.terraform == 'true'
+    if: github.event_name != 'pull_request' && needs.detect-changes.outputs.terraform == 'true' && needs.terraform-plan.result == 'success'
     environment: ${{ needs.detect-changes.outputs.environment }}
 
     steps:
@@ -389,7 +389,7 @@ jobs:
     name: Deploy Backend to Cloud Run
     runs-on: ubuntu-latest
     needs: [detect-changes, build-backend, terraform-apply]
-    if: github.event_name != 'pull_request' && needs.detect-changes.outputs.backend == 'true'
+    if: github.event_name != 'pull_request' && needs.detect-changes.outputs.backend == 'true' && needs.build-backend.result == 'success' && needs.terraform-apply.result == 'success'
     environment: ${{ needs.detect-changes.outputs.environment }}
 
     steps:
@@ -430,7 +430,7 @@ jobs:
     name: Deploy Frontend to App Engine
     runs-on: ubuntu-latest
     needs: [detect-changes, build-frontend, terraform-apply]
-    if: github.event_name != 'pull_request' && needs.detect-changes.outputs.frontend == 'true' && (needs.build-frontend.result == 'success' || needs.build-frontend.result == 'skipped')
+    if: github.event_name != 'pull_request' && needs.detect-changes.outputs.frontend == 'true' && (needs.build-frontend.result == 'success' || needs.build-frontend.result == 'skipped') && needs.terraform-apply.result == 'success'
     environment: ${{ needs.detect-changes.outputs.environment }}
 
     steps:
@@ -518,7 +518,7 @@ jobs:
     name: Smoke Tests
     runs-on: ubuntu-latest
     needs: [deploy-backend, deploy-frontend]
-    if: always() && (needs.deploy-backend.result == 'success' || needs.deploy-backend.result == 'skipped') && (needs.deploy-frontend.result == 'success' || needs.deploy-frontend.result == 'skipped')
+    if: (needs.deploy-backend.result == 'success' || needs.deploy-backend.result == 'skipped') && (needs.deploy-frontend.result == 'success' || needs.deploy-frontend.result == 'skipped')
 
     steps:
       - name: Checkout
@@ -533,7 +533,7 @@ jobs:
     name: Notify Deployment
     runs-on: ubuntu-latest
     needs: [detect-changes, deploy-backend, deploy-frontend, smoke-tests]
-    if: always()
+    if: always() && (needs.deploy-backend.result == 'success' || needs.deploy-backend.result == 'skipped') && (needs.deploy-frontend.result == 'success' || needs.deploy-frontend.result == 'skipped')
     environment: ${{ needs.detect-changes.outputs.environment }}
 
     steps:


### PR DESCRIPTION
- terraform-apply now requires terraform-plan to succeed
- deploy-backend now requires build-backend and terraform-apply to succeed
- deploy-frontend now requires terraform-apply to succeed
- smoke-tests removed always() to only run on successful deployments
- notify now checks deployment success before running