### PR TITLE
fix(terraform-wif): correct GitHub repository name and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,5 @@ service-account*.json
 .terraform.lock.hcl
 terraform.tfvars
 *.tfvars
+!*.tfvars.example
 !terraform/variables.tf


### PR DESCRIPTION
- Update github_repo from 'epitrello' to 'Epitrello' in dev.tfvars.example
- Add exception for *.tfvars.example files in .gitignore
- This fixes the Workload Identity Federation attribute condition error