### PR TITLE
fix(terraform): add environment variable to networking module and fix…

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,9 +22,10 @@ resource "google_service_account" "default" {
 module "networking" {
   source = "./modules/networking"
 
-  project_id = var.project_id
-  region     = var.region
-  app_name   = local.app_name
+  project_id  = var.project_id
+  region      = var.region
+  app_name    = local.app_name
+  environment = var.environment
 
   enable_private_ip       = var.enable_private_ip
   subnet_cidr             = var.subnet_cidr

--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -20,9 +20,9 @@ resource "google_compute_subnetwork" "subnet" {
 }
 
 # Serverless VPC Connector for Cloud Run
-# Note: Name must be lowercase and follow pattern ^[a-z][-a-z0-9]{0,23}[a-z0-9]$
 resource "google_vpc_access_connector" "connector" {
-  name          = lower("${var.app_name}-vpc-connector")
+  # Pattern: ^[a-z][-a-z0-9]{0,23}[a-z0-9]$ (max 25 chars total)
+  name          = lower("${var.environment}-vpc-conn")
   region        = var.region
   project       = var.project_id
   network       = google_compute_network.vpc.name

--- a/terraform/modules/networking/variables.tf
+++ b/terraform/modules/networking/variables.tf
@@ -13,6 +13,11 @@ variable "app_name" {
   type        = string
 }
 
+variable "environment" {
+  description = "Environment name (staging or production)"
+  type        = string
+}
+
 variable "subnet_cidr" {
   description = "CIDR range for the subnet"
   type        = string


### PR DESCRIPTION
… VPC connector name

- Add environment variable to networking module variables
- Pass environment from main.tf to networking module
- Fix VPC connector name to use shorter format (environment-vpc-conn) to comply with GCP naming constraints (max 25 chars)
- Align formatting in cloud_sql module for consistency