### PR TITLE
fix(terraform): adjust shared_buffers for db-f1-micro tier

### DIFF
--- a/terraform/modules/cloud-sql/main.tf
+++ b/terraform/modules/cloud-sql/main.tf
@@ -65,9 +65,12 @@ resource "google_sql_database_instance" "main" {
       value = "100"
     }
 
+    # shared_buffers must be adjusted based on instance tier
+    # db-f1-micro (e2-micro, 1024MB RAM): 13107-78643 (recommended: 32768-65536)
+    # db-n1-standard-1 (n1-standard-1, 3.75GB RAM): can use higher values (262144 = 256MB)
     database_flags {
       name  = "shared_buffers"
-      value = "262144" # 256MB in 8KB blocks
+      value = var.db_tier == "db-f1-micro" ? "32768" : "262144" # 32MB for micro, 256MB for standard
     }
 
     # Insights configuration


### PR DESCRIPTION
- Set shared_buffers to 32768 (32MB) for db-f1-micro tier to comply with GCP constraints (13107-78643 range)
- Keep shared_buffers at 262144 (256MB) for larger tiers like db-n1-standard-1
- Fixes error: 'shared_buffers must be between 13107 and 78643' for e2-micro instances