### PR TITLE
refactor: simplification secrets module et amélioration Terraform Apply

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -500,20 +500,16 @@ jobs:
           terraform apply -auto-approve tfplan 2>&1 | tee /tmp/apply.log || {
             if grep -q "Saved plan is stale" /tmp/apply.log; then
               echo "Plan is stale, regenerating..."
-              terraform plan -out=tfplan \
-                -parallelism=10 \
-                -refresh=false \
-                "${TF_VARS[@]}"
-              echo "Applying regenerated plan..."
-              terraform apply -auto-approve tfplan
+              terraform refresh "${TF_VARS[@]}" || true
+              terraform plan -out=tfplan -parallelism=10 -refresh=true "${TF_VARS[@]}"
+              terraform apply -auto-approve tfplan || exit 1
             elif grep -q "Your previous request to create the named bucket succeeded" /tmp/apply.log; then
-              echo "Bucket already exists, importing into state..."
+              echo "Bucket already exists, importing..."
               terraform import "${TF_VARS[@]}" \
-                google_storage_bucket.terraform_state epitrello-terraform-state || echo "Import failed, continuing..."
-              echo "Retrying apply..."
-              terraform apply -auto-approve tfplan
+                google_storage_bucket.terraform_state epitrello-terraform-state || true
+              terraform apply -auto-approve tfplan || exit 1
             else
-              echo "Apply failed with different error, see logs above"
+              echo "Apply failed, see logs above"
               exit 1
             fi
           }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -41,20 +41,22 @@ module "networking" {
 module "secrets" {
   source = "./modules/secrets"
 
-  project_id              = var.project_id
-  jwt_secret              = var.jwt_secret
-  database_password       = var.database_password
-  resend_api_key          = var.resend_api_key
-  google_client_id        = var.google_client_id
-  google_client_secret    = var.google_client_secret
-  microsoft_client_id     = var.microsoft_client_id
-  microsoft_client_secret = var.microsoft_client_secret
-  apple_client_id         = var.apple_client_id
-  apple_client_secret     = var.apple_client_secret
-  slack_client_id         = var.slack_client_id
-  slack_client_secret     = var.slack_client_secret
-  service_account_email   = google_service_account.default.email
-  labels                  = local.common_labels
+  project_id                    = var.project_id
+  jwt_secret                    = var.jwt_secret
+  database_password             = var.database_password
+  resend_api_key                = var.resend_api_key
+  google_client_id              = var.google_client_id
+  google_client_secret          = var.google_client_secret
+  microsoft_client_id           = var.microsoft_client_id
+  microsoft_client_secret       = var.microsoft_client_secret
+  apple_client_id               = var.apple_client_id
+  apple_client_secret           = var.apple_client_secret
+  slack_client_id               = var.slack_client_id
+  slack_client_secret           = var.slack_client_secret
+  backend_service_account_email = google_service_account.backend.email
+  labels                        = local.common_labels
+
+  depends_on = [google_service_account.backend]
 }
 
 # ===================================

--- a/terraform/modules/cloud-run/main.tf
+++ b/terraform/modules/cloud-run/main.tf
@@ -50,9 +50,12 @@ resource "google_cloud_run_v2_service" "backend" {
       }
 
       # Database connection (direct via public IP + SSL)
-      env {
-        name  = "DATABASE_URL"
-        value = var.database_connection
+      dynamic "env" {
+        for_each = var.database_connection != null && var.database_connection != "" ? [1] : []
+        content {
+          name  = "DATABASE_URL"
+          value = var.database_connection
+        }
       }
 
       # JWT Secret from Secret Manager

--- a/terraform/modules/cloud-run/variables.tf
+++ b/terraform/modules/cloud-run/variables.tf
@@ -46,6 +46,7 @@ variable "database_connection" {
   description = "PostgreSQL connection string"
   type        = string
   sensitive   = true
+  default     = null
 }
 
 variable "jwt_secret_name" {

--- a/terraform/modules/secrets/main.tf
+++ b/terraform/modules/secrets/main.tf
@@ -45,18 +45,18 @@ resource "google_secret_manager_secret_version" "db_password_version" {
 }
 
 # ===================================
-# IAM: Allow service account to access secrets
+# IAM: Allow backend service account to access secrets
 # ===================================
 resource "google_secret_manager_secret_iam_member" "jwt_secret_access" {
   secret_id = google_secret_manager_secret.jwt_secret.id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${var.service_account_email}"
+  member    = "serviceAccount:${var.backend_service_account_email}"
 }
 
 resource "google_secret_manager_secret_iam_member" "db_password_access" {
   secret_id = google_secret_manager_secret.db_password.id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${var.service_account_email}"
+  member    = "serviceAccount:${var.backend_service_account_email}"
 }
 
 # ===================================
@@ -93,7 +93,7 @@ resource "google_secret_manager_secret_iam_member" "resend_api_key_access" {
 
   secret_id = google_secret_manager_secret.resend_api_key[0].id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${var.service_account_email}"
+  member    = "serviceAccount:${var.backend_service_account_email}"
 
   depends_on = [google_secret_manager_secret.resend_api_key]
 }
@@ -132,7 +132,7 @@ resource "google_secret_manager_secret_iam_member" "google_client_id_access" {
 
   secret_id = google_secret_manager_secret.google_client_id[0].id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${var.service_account_email}"
+  member    = "serviceAccount:${var.backend_service_account_email}"
 
   depends_on = [google_secret_manager_secret.google_client_id]
 }
@@ -168,7 +168,7 @@ resource "google_secret_manager_secret_iam_member" "google_client_secret_access"
 
   secret_id = google_secret_manager_secret.google_client_secret[0].id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${var.service_account_email}"
+  member    = "serviceAccount:${var.backend_service_account_email}"
 
   depends_on = [google_secret_manager_secret.google_client_secret]
 }
@@ -207,7 +207,7 @@ resource "google_secret_manager_secret_iam_member" "microsoft_client_id_access" 
 
   secret_id = google_secret_manager_secret.microsoft_client_id[0].id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${var.service_account_email}"
+  member    = "serviceAccount:${var.backend_service_account_email}"
 
   depends_on = [google_secret_manager_secret.microsoft_client_id]
 }
@@ -243,7 +243,7 @@ resource "google_secret_manager_secret_iam_member" "microsoft_client_secret_acce
 
   secret_id = google_secret_manager_secret.microsoft_client_secret[0].id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${var.service_account_email}"
+  member    = "serviceAccount:${var.backend_service_account_email}"
 
   depends_on = [google_secret_manager_secret.microsoft_client_secret]
 }
@@ -282,7 +282,7 @@ resource "google_secret_manager_secret_iam_member" "apple_client_id_access" {
 
   secret_id = google_secret_manager_secret.apple_client_id[0].id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${var.service_account_email}"
+  member    = "serviceAccount:${var.backend_service_account_email}"
 
   depends_on = [google_secret_manager_secret.apple_client_id]
 }
@@ -318,7 +318,7 @@ resource "google_secret_manager_secret_iam_member" "apple_client_secret_access" 
 
   secret_id = google_secret_manager_secret.apple_client_secret[0].id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${var.service_account_email}"
+  member    = "serviceAccount:${var.backend_service_account_email}"
 
   depends_on = [google_secret_manager_secret.apple_client_secret]
 }
@@ -357,7 +357,7 @@ resource "google_secret_manager_secret_iam_member" "slack_client_id_access" {
 
   secret_id = google_secret_manager_secret.slack_client_id[0].id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${var.service_account_email}"
+  member    = "serviceAccount:${var.backend_service_account_email}"
 
   depends_on = [google_secret_manager_secret.slack_client_id]
 }
@@ -393,7 +393,7 @@ resource "google_secret_manager_secret_iam_member" "slack_client_secret_access" 
 
   secret_id = google_secret_manager_secret.slack_client_secret[0].id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${var.service_account_email}"
+  member    = "serviceAccount:${var.backend_service_account_email}"
 
   depends_on = [google_secret_manager_secret.slack_client_secret]
 }

--- a/terraform/modules/secrets/variables.tf
+++ b/terraform/modules/secrets/variables.tf
@@ -25,8 +25,8 @@ variable "database_password" {
   }
 }
 
-variable "service_account_email" {
-  description = "Service account email that needs access to secrets"
+variable "backend_service_account_email" {
+  description = "Backend service account email that needs access to secrets"
   type        = string
 }
 


### PR DESCRIPTION
- Simplifie les messages Terraform Apply dans le workflow CI/CD
- Corrige la configuration DATABASE_URL avec dynamic env block
- Ajoute l'accès aux secrets pour le service account backend
- Simplifie le module secrets : supprime service_account_email, garde uniquement backend_service_account_email
- Applique le principe du moindre privilège pour les secrets