### PR TITLE
refactor: create service-accounts module and add IAM permissions for …

### DIFF
--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -52,6 +52,23 @@ resource "google_storage_bucket" "terraform_state" {
   }
 }
 
+# ===================================
+# IAM: Grant access to project owners and editors
+# ===================================
+# With uniform_bucket_level_access = true, IAM permissions must be explicit
+# Project owners and editors need access to read/write Terraform state
+resource "google_storage_bucket_iam_member" "owners" {
+  bucket = google_storage_bucket.terraform_state.name
+  role   = "roles/storage.objectAdmin"
+  member = "projectOwner:${var.project_id}"
+}
+
+resource "google_storage_bucket_iam_member" "editors" {
+  bucket = google_storage_bucket.terraform_state.name
+  role   = "roles/storage.objectAdmin"
+  member = "projectEditor:${var.project_id}"
+}
+
 output "terraform_state_bucket" {
   description = "Bucket for storing Terraform state"
   value       = google_storage_bucket.terraform_state.name

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -53,10 +53,10 @@ module "secrets" {
   apple_client_secret           = var.apple_client_secret
   slack_client_id               = var.slack_client_id
   slack_client_secret           = var.slack_client_secret
-  backend_service_account_email = google_service_account.backend.email
+  backend_service_account_email = module.service_accounts.backend_service_account_email
   labels                        = local.common_labels
 
-  depends_on = [google_service_account.backend]
+  depends_on = [module.service_accounts]
 }
 
 # ===================================
@@ -83,14 +83,13 @@ module "cloud_sql" {
 }
 
 # ===================================
-# Cloud Run Backend Service Account
+# Service Accounts Module
 # ===================================
-# Create the service account separately to avoid circular dependency
-# between cloud_storage and cloud_run modules
-resource "google_service_account" "backend" {
-  account_id   = "${local.app_name}-backend-sa"
-  display_name = "Cloud Run Backend Service Account"
-  project      = var.project_id
+module "service_accounts" {
+  source = "./modules/service-accounts"
+
+  project_id = var.project_id
+  app_name   = local.app_name
 }
 
 # ===================================
@@ -104,7 +103,7 @@ module "cloud_storage" {
   app_name                        = local.app_name
   location                        = var.storage_location
   service_account_email           = google_service_account.default.email
-  cloud_run_service_account_email = google_service_account.backend.email
+  cloud_run_service_account_email = module.service_accounts.backend_service_account_email
 
   # CORS configuration for frontend
   cors_origins = [
@@ -114,7 +113,7 @@ module "cloud_storage" {
 
   labels = local.common_labels
 
-  depends_on = [google_service_account.backend]
+  depends_on = [module.service_accounts]
 }
 
 # ===================================
@@ -131,7 +130,7 @@ module "cloud_run" {
   memory                = var.backend_memory
   min_instances         = var.backend_min_instances
   max_instances         = var.backend_max_instances
-  service_account_email = google_service_account.backend.email
+  service_account_email = module.service_accounts.backend_service_account_email
 
   database_connection                 = module.cloud_sql.connection_string
   jwt_secret_name                     = module.secrets.jwt_secret_name
@@ -154,8 +153,8 @@ module "cloud_run" {
     module.secrets,
     module.networking,
     module.cloud_storage,
-    google_service_account.default,
-    google_service_account.backend
+    module.service_accounts,
+    google_service_account.default
   ]
 }
 

--- a/terraform/modules/service-accounts/main.tf
+++ b/terraform/modules/service-accounts/main.tf
@@ -1,0 +1,13 @@
+# ===================================
+# Backend Service Account
+# ===================================
+# Service account for Cloud Run backend service
+# This service account is used by the backend to access:
+# - Secret Manager (JWT, database password, OAuth secrets)
+# - Cloud Storage (file uploads)
+resource "google_service_account" "backend" {
+  account_id   = "${var.app_name}-backend-sa"
+  display_name = "Cloud Run Backend Service Account"
+  description  = "Service account for Cloud Run backend service"
+  project      = var.project_id
+}

--- a/terraform/modules/service-accounts/outputs.tf
+++ b/terraform/modules/service-accounts/outputs.tf
@@ -1,0 +1,14 @@
+output "backend_service_account_email" {
+  description = "Backend service account email"
+  value       = google_service_account.backend.email
+}
+
+output "backend_service_account_id" {
+  description = "Backend service account ID"
+  value       = google_service_account.backend.id
+}
+
+output "backend_service_account_name" {
+  description = "Backend service account name"
+  value       = google_service_account.backend.name
+}

--- a/terraform/modules/service-accounts/variables.tf
+++ b/terraform/modules/service-accounts/variables.tf
@@ -1,0 +1,9 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "app_name" {
+  description = "Application name (e.g., staging-epitrello)"
+  type        = string
+}


### PR DESCRIPTION
…Terraform state bucket

- Create terraform/modules/service-accounts module for backend service account
- Update terraform/main.tf to use service_accounts module instead of inline resource
- Add IAM permissions for project owners and editors to Terraform state bucket
- Ensure uniform_bucket_level_access works correctly with explicit IAM bindings