### PR TITLE
fix: correct startup_probe timeout_seconds to be less than period_sec…

### DIFF
--- a/terraform/modules/cloud-run-frontend/main.tf
+++ b/terraform/modules/cloud-run-frontend/main.tf
@@ -79,7 +79,7 @@ resource "google_cloud_run_v2_service" "frontend" {
           port = 8080
         }
         initial_delay_seconds = 5
-        timeout_seconds       = 10
+        timeout_seconds       = 1
         period_seconds        = 3
         failure_threshold     = 20
       }

--- a/terraform/modules/cloud-run/main.tf
+++ b/terraform/modules/cloud-run/main.tf
@@ -224,7 +224,7 @@ resource "google_cloud_run_v2_service" "backend" {
           port = 8080
         }
         initial_delay_seconds = 5
-        timeout_seconds       = 10
+        timeout_seconds       = 1
         period_seconds        = 3
         failure_threshold     = 20
       }


### PR DESCRIPTION
…onds

- Fix startup_probe timeout_seconds from 10 to 1 in backend module
- Fix startup_probe timeout_seconds from 10 to 1 in frontend module
- Resolves Cloud Run deployment error: timeout_seconds must be less than period_seconds