### PR TITLE
fix(migrations): filtrer la base postgres par défaut pour utiliser la…

### DIFF
--- a/.github/actions/run-migrations/action.yml
+++ b/.github/actions/run-migrations/action.yml
@@ -39,12 +39,14 @@ runs:
         PROJECT_ID="${{ inputs.project_id }}"
 
         PUBLIC_IP=$(gcloud sql instances describe $INSTANCE --format="value(ipAddresses[0].ipAddress)" 2>/dev/null || echo "")
-        DB_NAME=$(gcloud sql databases list --instance=$INSTANCE --format="value(name)" | head -1 || echo "epitrello")
+        # Filter out 'postgres' default database and get the application database
+        DB_NAME=$(gcloud sql databases list --instance=$INSTANCE --format="value(name)" | grep -v "^postgres$" | head -1 || echo "epitrello-db")
         DB_USER=$(gcloud sql users list --instance=$INSTANCE --format="value(name)" | grep -v "postgres" | head -1 || echo "epitrello_user")
 
         echo "public_ip=$PUBLIC_IP" >> $GITHUB_OUTPUT
         echo "db_name=$DB_NAME" >> $GITHUB_OUTPUT
         echo "db_user=$DB_USER" >> $GITHUB_OUTPUT
+        echo "Using database: $DB_NAME"
 
     - name: Get database password from Secret Manager
       id: db-password

--- a/.github/workflows/database-migrations.yml
+++ b/.github/workflows/database-migrations.yml
@@ -100,7 +100,8 @@ jobs:
           # Get database connection details
           CONNECTION_NAME=$(gcloud sql instances describe $INSTANCE --format="value(connectionName)")
           PUBLIC_IP=$(gcloud sql instances describe $INSTANCE --format="value(ipAddresses[0].ipAddress)" 2>/dev/null || echo "")
-          DB_NAME=$(gcloud sql databases list --instance=$INSTANCE --format="value(name)" | head -1 || echo "epitrello")
+          # Filter out 'postgres' default database and get the application database
+          DB_NAME=$(gcloud sql databases list --instance=$INSTANCE --format="value(name)" | grep -v "^postgres$" | head -1 || echo "epitrello-db")
           DB_USER=$(gcloud sql users list --instance=$INSTANCE --format="value(name)" | grep -v "postgres" | head -1 || echo "epitrello_user")
 
           echo "connection_name=$CONNECTION_NAME" >> $GITHUB_OUTPUT
@@ -214,7 +215,8 @@ jobs:
           # Get database connection details
           CONNECTION_NAME=$(gcloud sql instances describe $INSTANCE --format="value(connectionName)")
           PUBLIC_IP=$(gcloud sql instances describe $INSTANCE --format="value(ipAddresses[0].ipAddress)" 2>/dev/null || echo "")
-          DB_NAME=$(gcloud sql databases list --instance=$INSTANCE --format="value(name)" | head -1 || echo "epitrello")
+          # Filter out 'postgres' default database and get the application database
+          DB_NAME=$(gcloud sql databases list --instance=$INSTANCE --format="value(name)" | grep -v "^postgres$" | head -1 || echo "epitrello-db")
           DB_USER=$(gcloud sql users list --instance=$INSTANCE --format="value(name)" | grep -v "postgres" | head -1 || echo "epitrello_user")
 
           echo "connection_name=$CONNECTION_NAME" >> $GITHUB_OUTPUT
@@ -323,7 +325,8 @@ jobs:
           # Get database connection details
           CONNECTION_NAME=$(gcloud sql instances describe $INSTANCE --format="value(connectionName)")
           PUBLIC_IP=$(gcloud sql instances describe $INSTANCE --format="value(ipAddresses[0].ipAddress)" 2>/dev/null || echo "")
-          DB_NAME=$(gcloud sql databases list --instance=$INSTANCE --format="value(name)" | head -1 || echo "epitrello")
+          # Filter out 'postgres' default database and get the application database
+          DB_NAME=$(gcloud sql databases list --instance=$INSTANCE --format="value(name)" | grep -v "^postgres$" | head -1 || echo "epitrello-db")
           DB_USER=$(gcloud sql users list --instance=$INSTANCE --format="value(name)" | grep -v "postgres" | head -1 || echo "epitrello_user")
 
           echo "connection_name=$CONNECTION_NAME" >> $GITHUB_OUTPUT


### PR DESCRIPTION
… bonne base de données

- Corrige la sélection de la base de données dans run-migrations
- Filtre 'postgres' pour utiliser 'epitrello-db' à la place
- Applique la même correction dans database-migrations.yml (3 occurrences)
- Résout le problème où les migrations s'appliquaient sur la mauvaise base