### PR TITLE
fix(ci/cd): add missing checkout step in notify job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -601,6 +601,9 @@ jobs:
       id-token: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Setup GCP Authentication
         uses: ./.github/actions/setup-gcp-auth
         with:


### PR DESCRIPTION
- Add checkout step before using composite actions in notify job
- Fixes error: Can't find 'action.yml' under setup-gcp-auth