### PR TITLE
feat(terraform): add documentation bucket module and CI/CD deployment

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -137,8 +137,9 @@ jobs:
       - name: Generate GraphQL documentation
         working-directory: backend
         run: pnpm docs:generate
+        continue-on-error: true
 
-      - name: Upload GraphQL documentation
+      - name: Upload GraphQL documentation artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -567,6 +567,76 @@ jobs:
             --region ${{ env.GCP_REGION }} \
             --platform managed
 
+  deploy-docs:
+    name: Deploy GraphQL Documentation
+    runs-on: ubuntu-latest
+    needs: [detect-changes, terraform-apply, build-backend]
+    if: github.event_name != 'pull_request' && needs.terraform-apply.result == 'success' && needs.build-backend.result == 'success'
+    environment: ${{ needs.detect-changes.outputs.environment }}
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup GCP Authentication
+        uses: ./.github/actions/setup-gcp-auth
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: backend/pnpm-lock.yaml
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Install dependencies
+        working-directory: backend
+        run: pnpm install --frozen-lockfile
+
+      - name: Build application
+        working-directory: backend
+        run: pnpm build
+
+      - name: Generate GraphQL documentation
+        working-directory: backend
+        run: pnpm docs:generate
+        continue-on-error: true
+
+      - name: Get documentation bucket name
+        id: bucket
+        shell: bash
+        run: |
+          ENV="${{ needs.detect-changes.outputs.environment }}"
+          PROJECT_ID="${{ secrets.GCP_PROJECT_ID }}"
+          BUCKET_NAME="${PROJECT_ID}-${ENV}-epitrello-docs"
+          echo "bucket_name=$BUCKET_NAME" >> $GITHUB_OUTPUT
+          echo "Documentation bucket: $BUCKET_NAME"
+
+      - name: Upload documentation to GCS
+        if: success()
+        working-directory: backend
+        run: |
+          BUCKET="${{ steps.bucket.outputs.bucket_name }}"
+          if [ -d "docs/graphql" ]; then
+            echo "Uploading documentation to gs://${BUCKET}/"
+            gsutil -m rsync -r -d docs/graphql/ gs://${BUCKET}/
+            echo "Documentation uploaded successfully"
+            echo "Public URL: https://storage.googleapis.com/${BUCKET}/index.html"
+          else
+            echo "Documentation directory not found, skipping upload"
+          fi
+        continue-on-error: true
+
   smoke-tests:
     name: Smoke Tests
     runs-on: ubuntu-latest
@@ -592,6 +662,7 @@ jobs:
         run-migrations,
         deploy-backend,
         deploy-frontend,
+        deploy-docs,
         smoke-tests,
       ]
     if: always() && (needs.terraform-apply.result == 'success' || needs.terraform-apply.result == 'skipped') && (needs.deploy-backend.result == 'success' || needs.deploy-backend.result == 'skipped') && (needs.deploy-frontend.result == 'success' || needs.deploy-frontend.result == 'skipped')

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -178,3 +178,19 @@ module "cloud_run_frontend" {
 
   depends_on = [module.cloud_run]
 }
+
+# ===================================
+# Documentation Bucket Module
+# ===================================
+module "docs_bucket" {
+  source = "./modules/docs-bucket"
+
+  project_id            = var.project_id
+  app_name              = local.app_name
+  location              = var.storage_location
+  service_account_email = google_service_account.default.email
+
+  labels = local.common_labels
+
+  depends_on = [google_service_account.default]
+}

--- a/terraform/modules/docs-bucket/main.tf
+++ b/terraform/modules/docs-bucket/main.tf
@@ -1,0 +1,62 @@
+# ===================================
+# Storage Bucket for GraphQL Documentation
+# ===================================
+resource "google_storage_bucket" "docs" {
+  name          = "${var.project_id}-${var.app_name}-docs"
+  location      = var.location
+  project       = var.project_id
+  force_destroy = var.force_destroy
+
+  # Uniform bucket-level access (recommended)
+  uniform_bucket_level_access = true
+
+  # Storage class for static website hosting
+  storage_class = var.storage_class
+
+
+  # CORS configuration for web access
+  cors {
+    origin          = var.cors_origins
+    method          = ["GET", "HEAD"]
+    response_header = ["Content-Type", "Content-Length", "Content-Range", "Accept-Ranges"]
+    max_age_seconds = 3600
+  }
+
+  # Lifecycle rules
+  lifecycle_rule {
+    condition {
+      age = 90 # Delete old versions after 90 days
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  # Versioning (recommended for documentation)
+  versioning {
+    enabled = var.versioning_enabled
+  }
+
+  # Labels
+  labels = var.labels
+}
+
+# ===================================
+# IAM: Public read access for documentation
+# ===================================
+resource "google_storage_bucket_iam_member" "public_read" {
+  bucket = google_storage_bucket.docs.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
+
+# ===================================
+# IAM: Service account can write/update documentation
+# ===================================
+resource "google_storage_bucket_iam_member" "service_account_admin" {
+  bucket = google_storage_bucket.docs.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${var.service_account_email}"
+
+  depends_on = [google_storage_bucket.docs]
+}

--- a/terraform/modules/docs-bucket/outputs.tf
+++ b/terraform/modules/docs-bucket/outputs.tf
@@ -1,0 +1,24 @@
+output "bucket_name" {
+  description = "Documentation bucket name"
+  value       = google_storage_bucket.docs.name
+}
+
+output "bucket_url" {
+  description = "Documentation bucket URL"
+  value       = google_storage_bucket.docs.url
+}
+
+output "bucket_self_link" {
+  description = "Documentation bucket self link"
+  value       = google_storage_bucket.docs.self_link
+}
+
+output "bucket_location" {
+  description = "Bucket location"
+  value       = google_storage_bucket.docs.location
+}
+
+output "public_url" {
+  description = "Public URL to access the documentation"
+  value       = "https://storage.googleapis.com/${google_storage_bucket.docs.name}/index.html"
+}

--- a/terraform/modules/docs-bucket/variables.tf
+++ b/terraform/modules/docs-bucket/variables.tf
@@ -1,0 +1,60 @@
+variable "project_id" {
+  description = "GCP Project ID"
+  type        = string
+}
+
+variable "app_name" {
+  description = "Application name"
+  type        = string
+}
+
+variable "location" {
+  description = "Bucket location (EU, US, ASIA)"
+  type        = string
+  default     = "EU"
+
+  validation {
+    condition     = contains(["EU", "US", "ASIA"], var.location)
+    error_message = "Location must be EU, US, or ASIA."
+  }
+}
+
+variable "storage_class" {
+  description = "Storage class"
+  type        = string
+  default     = "STANDARD"
+
+  validation {
+    condition     = contains(["STANDARD", "NEARLINE", "COLDLINE", "ARCHIVE"], var.storage_class)
+    error_message = "Storage class must be STANDARD, NEARLINE, COLDLINE, or ARCHIVE."
+  }
+}
+
+variable "cors_origins" {
+  description = "CORS allowed origins"
+  type        = list(string)
+  default     = ["*"]
+}
+
+variable "force_destroy" {
+  description = "Allow bucket destruction even if not empty (use with caution!)"
+  type        = bool
+  default     = false
+}
+
+variable "versioning_enabled" {
+  description = "Enable object versioning"
+  type        = bool
+  default     = true
+}
+
+variable "service_account_email" {
+  description = "Service account email for IAM binding (for CI/CD deployment)"
+  type        = string
+}
+
+variable "labels" {
+  description = "Labels to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -71,6 +71,19 @@ output "storage_bucket_url" {
 }
 
 # ===================================
+# Documentation Outputs
+# ===================================
+output "docs_bucket_name" {
+  description = "Documentation bucket name"
+  value       = module.docs_bucket.bucket_name
+}
+
+output "docs_bucket_public_url" {
+  description = "Public URL to access the GraphQL documentation"
+  value       = module.docs_bucket.public_url
+}
+
+# ===================================
 # Secrets Outputs
 # ===================================
 output "jwt_secret_name" {


### PR DESCRIPTION
- Create docs-bucket Terraform module for GraphQL documentation hosting
- Configure bucket with public read access for documentation
- Add service account permissions for CI/CD deployment
- Integrate module in main Terraform configuration
- Add documentation deployment job in deploy workflow
- Generate and upload documentation to GCS bucket
- Add outputs for documentation bucket name and public URL