### PR TITLE
fix(ci): use setup-backend action for docs deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -587,21 +587,8 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'pnpm'
-          cache-dependency-path: backend/pnpm-lock.yaml
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
-
-      - name: Install dependencies
-        working-directory: backend
-        run: pnpm install --frozen-lockfile
+      - name: Setup Backend
+        uses: ./.github/actions/setup-backend
 
       - name: Build application
         working-directory: backend


### PR DESCRIPTION
- Replace manual Node.js/pnpm setup with setup-backend action
- Ensures consistent environment setup across workflows
- Fixes 'pnpm not found' error in deploy-docs job