### PR TITLE
fix(terraform): add deployer service account permissions for docs bucket

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -185,10 +185,11 @@ module "cloud_run_frontend" {
 module "docs_bucket" {
   source = "./modules/docs-bucket"
 
-  project_id            = var.project_id
-  app_name              = local.app_name
-  location              = var.storage_location
-  service_account_email = google_service_account.default.email
+  project_id                     = var.project_id
+  app_name                       = local.app_name
+  location                       = var.storage_location
+  service_account_email          = google_service_account.default.email
+  deployer_service_account_email = var.deployer_service_account_email
 
   labels = local.common_labels
 

--- a/terraform/modules/docs-bucket/main.tf
+++ b/terraform/modules/docs-bucket/main.tf
@@ -60,3 +60,18 @@ resource "google_storage_bucket_iam_member" "service_account_admin" {
 
   depends_on = [google_storage_bucket.docs]
 }
+
+# ===================================
+# IAM: Deployer service account (for CI/CD)
+# ===================================
+# Grant permissions to the deployer service account used by CI/CD
+# This allows the GitHub Actions workflow to upload documentation
+resource "google_storage_bucket_iam_member" "deployer_admin" {
+  count = var.deployer_service_account_email != null && var.deployer_service_account_email != "" ? 1 : 0
+
+  bucket = google_storage_bucket.docs.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${var.deployer_service_account_email}"
+
+  depends_on = [google_storage_bucket.docs]
+}

--- a/terraform/modules/docs-bucket/variables.tf
+++ b/terraform/modules/docs-bucket/variables.tf
@@ -53,6 +53,12 @@ variable "service_account_email" {
   type        = string
 }
 
+variable "deployer_service_account_email" {
+  description = "Deployer service account email for CI/CD (optional, if different from service_account_email)"
+  type        = string
+  default     = null
+}
+
 variable "labels" {
   description = "Labels to apply to resources"
   type        = map(string)


### PR DESCRIPTION
- Add deployer_service_account_email variable to docs-bucket module
- Grant storage.objectAdmin role to deployer service account
- Allow CI/CD to upload documentation to GCS bucket
- Fixes 401 permission denied error during documentation upload