### PR TITLE
docs: add deployer_service_account_email to tfvars examples

### DIFF
--- a/terraform/env/production.tfvars.example
+++ b/terraform/env/production.tfvars.example
@@ -44,6 +44,14 @@ frontend_max_instances = 20
 storage_location = "EU"
 
 # ===================================
+# CI/CD Configuration
+# ===================================
+# Service account used by GitHub Actions for deployments
+# This should match the GCP_SERVICE_ACCOUNT secret in GitHub
+# Required for documentation bucket uploads
+# deployer_service_account_email = "epitrello-deployer@your-project-id.iam.gserviceaccount.com"
+
+# ===================================
 # Networking Configuration
 # ===================================
 # Enable private IP for Cloud SQL (recommended for production)

--- a/terraform/env/staging.tfvars.example
+++ b/terraform/env/staging.tfvars.example
@@ -44,6 +44,14 @@ frontend_max_instances = 10
 storage_location = "EU"
 
 # ===================================
+# CI/CD Configuration
+# ===================================
+# Service account used by GitHub Actions for deployments
+# This should match the GCP_SERVICE_ACCOUNT secret in GitHub
+# Required for documentation bucket uploads
+# deployer_service_account_email = "epitrello-deployer@your-project-id.iam.gserviceaccount.com"
+
+# ===================================
 # Networking Configuration
 # ===================================
 enable_private_ip = false


### PR DESCRIPTION
- Add commented example in staging and production tfvars
- Document that it should match GCP_SERVICE_ACCOUNT GitHub secret
- Required for documentation bucket uploads