### PR TITLE
refactor(ci): use gcloud storage instead of gsutil

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -616,7 +616,7 @@ jobs:
           BUCKET="${{ steps.bucket.outputs.bucket_name }}"
           if [ -d "docs/graphql" ]; then
             echo "Uploading documentation to gs://${BUCKET}/"
-            gsutil -m rsync -r -d docs/graphql/ gs://${BUCKET}/
+            gcloud storage rsync -r --delete docs/graphql/ gs://${BUCKET}/
             echo "Documentation uploaded successfully"
             echo "Public URL: https://storage.googleapis.com/${BUCKET}/index.html"
           else


### PR DESCRIPTION
- Replace gsutil with gcloud storage (modern Google Cloud CLI)
- gcloud storage is the recommended tool for Cloud Storage operations
- More consistent with other gcloud commands in the workflow