### PR TITLE
test: expand labels and checklists coverage

### DIFF
--- a/backend/src/modules/cards/cards.resolver.spec.ts
+++ b/backend/src/modules/cards/cards.resolver.spec.ts
@@ -247,4 +247,26 @@ describe('CardsResolver', () => {
       expect(service.removeLabelFromCard).toHaveBeenCalledWith('card-1', 'label-1', mockUser.id);
     });
   });
+
+  describe('labels', () => {
+    it('should resolve labels for a card', async () => {
+      mockLabelsLoader.load.mockResolvedValue([{ id: 'label-1' }]);
+
+      const result = await resolver.labels(mockCard as any);
+
+      expect(result).toHaveLength(1);
+      expect(mockLabelsLoader.load).toHaveBeenCalledWith('card-1');
+    });
+  });
+
+  describe('checklists', () => {
+    it('should resolve checklists for a card', async () => {
+      mockChecklistsLoader.load.mockResolvedValue([{ id: 'checklist-1' }]);
+
+      const result = await resolver.checklists(mockCard as any);
+
+      expect(result).toHaveLength(1);
+      expect(mockChecklistsLoader.load).toHaveBeenCalledWith('card-1');
+    });
+  });
 });

--- a/backend/src/modules/cards/cards.service.spec.ts
+++ b/backend/src/modules/cards/cards.service.spec.ts
@@ -562,6 +562,19 @@ describe('CardsService', () => {
         BadRequestException,
       );
     });
+
+    it('should throw NotFoundException when label does not exist', async () => {
+      mockPrismaService.card.findUnique.mockResolvedValueOnce({
+        ...mockCard,
+        list: { boardId: 'board-1' },
+      });
+      mockPrismaService.label.findUnique.mockResolvedValue(null);
+      mockPrismaService.board.findUnique.mockResolvedValue(mockBoard);
+
+      await expect(service.addLabelToCard('card-1', 'label-1', mockUser.id)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
   });
 
   describe('removeLabelFromCard', () => {

--- a/backend/src/modules/cards/dataloaders/cards.dataloader.spec.ts
+++ b/backend/src/modules/cards/dataloaders/cards.dataloader.spec.ts
@@ -1,0 +1,91 @@
+import { CardsDataLoader } from './cards.dataloader';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+jest.mock('dataloader', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation((batchFn) => ({
+    loadMany: (keys: readonly string[]) => Promise.resolve(batchFn(keys)),
+  })),
+}));
+
+describe('CardsDataLoader', () => {
+  let dataloader: CardsDataLoader;
+  let prisma: PrismaService;
+
+  const mockPrismaService = {
+    card: {
+      findMany: jest.fn(),
+    },
+    cardAssignee: {
+      findMany: jest.fn(),
+    },
+    cardLabel: {
+      findMany: jest.fn(),
+    },
+    checklist: {
+      findMany: jest.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    prisma = mockPrismaService as unknown as PrismaService;
+    dataloader = new CardsDataLoader(prisma);
+    jest.clearAllMocks();
+  });
+
+  it('should create cards by list loader', async () => {
+    mockPrismaService.card.findMany.mockResolvedValue([
+      { id: 'card-1', listId: 'list-1', position: 0 },
+      { id: 'card-2', listId: 'list-2', position: 1 },
+    ]);
+
+    const loader = dataloader.createCardsByListLoader();
+    const result = await loader.loadMany(['list-1', 'list-2']);
+
+    expect(result[0]).toHaveLength(1);
+    expect(result[1]).toHaveLength(1);
+    expect(mockPrismaService.card.findMany).toHaveBeenCalled();
+  });
+
+  it('should create assignees by card loader', async () => {
+    mockPrismaService.cardAssignee.findMany.mockResolvedValue([
+      { cardId: 'card-1', user: { id: 'user-1' } },
+      { cardId: 'card-2', user: { id: 'user-2' } },
+    ]);
+
+    const loader = dataloader.createAssigneesByCardLoader();
+    const result = await loader.loadMany(['card-1', 'card-2']);
+
+    expect(result[0]).toHaveLength(1);
+    expect(result[1]).toHaveLength(1);
+    expect(mockPrismaService.cardAssignee.findMany).toHaveBeenCalled();
+  });
+
+  it('should create labels by card loader', async () => {
+    mockPrismaService.cardLabel.findMany.mockResolvedValue([
+      { cardId: 'card-1', label: { id: 'label-1' } },
+      { cardId: 'card-2', label: { id: 'label-2' } },
+    ]);
+
+    const loader = dataloader.createLabelsByCardLoader();
+    const result = await loader.loadMany(['card-1', 'card-2']);
+
+    expect(result[0]).toHaveLength(1);
+    expect(result[1]).toHaveLength(1);
+    expect(mockPrismaService.cardLabel.findMany).toHaveBeenCalled();
+  });
+
+  it('should create checklists by card loader', async () => {
+    mockPrismaService.checklist.findMany.mockResolvedValue([
+      { id: 'checklist-1', cardId: 'card-1', items: [] },
+      { id: 'checklist-2', cardId: 'card-2', items: [] },
+    ]);
+
+    const loader = dataloader.createChecklistsByCardLoader();
+    const result = await loader.loadMany(['card-1', 'card-2']);
+
+    expect(result[0]).toHaveLength(1);
+    expect(result[1]).toHaveLength(1);
+    expect(mockPrismaService.checklist.findMany).toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/checklists/checklists.resolver.spec.ts
+++ b/backend/src/modules/checklists/checklists.resolver.spec.ts
@@ -67,4 +67,40 @@ describe('ChecklistsResolver', () => {
     expect(result).toHaveLength(1);
     expect(service.findByCard).toHaveBeenCalledWith('card-1', mockUser.id);
   });
+
+  it('should create a checklist', async () => {
+    mockChecklistsService.createChecklist.mockResolvedValue(mockChecklist);
+
+    const result = await resolver.createChecklist(
+      { cardId: 'card-1', title: 'Checklist' },
+      mockUser,
+    );
+
+    expect(result).toEqual(mockChecklist);
+    expect(service.createChecklist).toHaveBeenCalledWith(
+      { cardId: 'card-1', title: 'Checklist' },
+      mockUser.id,
+    );
+  });
+
+  it('should update a checklist', async () => {
+    mockChecklistsService.updateChecklist.mockResolvedValue(mockChecklist);
+
+    const result = await resolver.updateChecklist(
+      { id: 'checklist-1', title: 'Updated' },
+      mockUser,
+    );
+
+    expect(result).toEqual(mockChecklist);
+    expect(service.updateChecklist).toHaveBeenCalled();
+  });
+
+  it('should delete a checklist', async () => {
+    mockChecklistsService.deleteChecklist.mockResolvedValue(true);
+
+    const result = await resolver.deleteChecklist('checklist-1', mockUser);
+
+    expect(result).toBe(true);
+    expect(service.deleteChecklist).toHaveBeenCalledWith('checklist-1', mockUser.id);
+  });
 });

--- a/backend/src/modules/checklists/checklists.service.spec.ts
+++ b/backend/src/modules/checklists/checklists.service.spec.ts
@@ -113,4 +113,72 @@ describe('ChecklistsService', () => {
     expect(result.id).toBe('item-1');
     expect(prismaService.checklistItem.create).toHaveBeenCalled();
   });
+
+  it('should update a checklist item', async () => {
+    mockPrismaService.checklistItem.findUnique.mockResolvedValue({
+      id: 'item-1',
+      checklistId: 'checklist-1',
+      content: 'Old',
+      checked: false,
+      position: 0,
+    });
+    mockPrismaService.checklist.findUnique.mockResolvedValue({
+      id: 'checklist-1',
+      cardId: 'card-1',
+    });
+    mockPrismaService.card.findUnique.mockResolvedValue({
+      id: 'card-1',
+      list: { boardId: 'board-1' },
+    });
+    mockPrismaService.board.findUnique.mockResolvedValue(mockBoard);
+    mockPrismaService.checklistItem.update.mockResolvedValue({
+      id: 'item-1',
+      checklistId: 'checklist-1',
+      content: 'New',
+      checked: true,
+      position: 1,
+    });
+
+    const result = await service.updateChecklistItem(
+      { id: 'item-1', content: 'New', checked: true, position: 1 },
+      mockUser.id,
+    );
+
+    expect(result.content).toBe('New');
+    expect(prismaService.checklistItem.update).toHaveBeenCalled();
+  });
+
+  it('should reorder checklist items', async () => {
+    mockPrismaService.checklist.findUnique.mockResolvedValue({
+      id: 'checklist-1',
+      cardId: 'card-1',
+    });
+    mockPrismaService.card.findUnique.mockResolvedValue({
+      id: 'card-1',
+      list: { boardId: 'board-1' },
+    });
+    mockPrismaService.board.findUnique.mockResolvedValue(mockBoard);
+    mockPrismaService.checklistItem.findMany.mockResolvedValue([
+      { id: 'item-1', checklistId: 'checklist-1' },
+      { id: 'item-2', checklistId: 'checklist-1' },
+    ]);
+    mockPrismaService.$transaction.mockResolvedValue([
+      { id: 'item-1', position: 0 },
+      { id: 'item-2', position: 1 },
+    ]);
+
+    const result = await service.reorderChecklistItems(
+      {
+        checklistId: 'checklist-1',
+        itemPositions: [
+          { id: 'item-1', position: 0 },
+          { id: 'item-2', position: 1 },
+        ],
+      },
+      mockUser.id,
+    );
+
+    expect(result).toHaveLength(2);
+    expect(prismaService.$transaction).toHaveBeenCalled();
+  });
 });

--- a/backend/src/modules/labels/labels.resolver.spec.ts
+++ b/backend/src/modules/labels/labels.resolver.spec.ts
@@ -65,4 +65,25 @@ describe('LabelsResolver', () => {
     expect(result).toEqual(mockLabel);
     expect(service.create).toHaveBeenCalled();
   });
+
+  it('should update a label', async () => {
+    mockLabelsService.update.mockResolvedValue(mockLabel);
+
+    const result = await resolver.updateLabel(
+      { id: 'label-1', name: 'Updated', color: 'blue' },
+      mockUser,
+    );
+
+    expect(result).toEqual(mockLabel);
+    expect(service.update).toHaveBeenCalled();
+  });
+
+  it('should delete a label', async () => {
+    mockLabelsService.delete.mockResolvedValue(true);
+
+    const result = await resolver.deleteLabel('label-1', mockUser);
+
+    expect(result).toBe(true);
+    expect(service.delete).toHaveBeenCalledWith('label-1', mockUser.id);
+  });
 });

--- a/backend/src/modules/labels/labels.service.spec.ts
+++ b/backend/src/modules/labels/labels.service.spec.ts
@@ -94,4 +94,28 @@ describe('LabelsService', () => {
     expect(result.name).toBe('New');
     expect(prismaService.label.update).toHaveBeenCalled();
   });
+
+  it('should reject unsupported color', async () => {
+    mockPrismaService.board.findUnique.mockResolvedValue(mockBoard);
+
+    await expect(
+      service.create({ boardId: 'board-1', name: 'Bad', color: 'beige' }, mockUser.id),
+    ).rejects.toThrow('Label color is not supported');
+  });
+
+  it('should delete a label', async () => {
+    mockPrismaService.label.findUnique.mockResolvedValue({
+      id: 'label-1',
+      boardId: 'board-1',
+      name: 'Urgent',
+      color: 'red',
+    });
+    mockPrismaService.board.findUnique.mockResolvedValue(mockBoard);
+    mockPrismaService.label.delete.mockResolvedValue({});
+
+    const result = await service.delete('label-1', mockUser.id);
+
+    expect(result).toBe(true);
+    expect(prismaService.label.delete).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Add DataLoader tests and cover additional label/checklist cases in cards, labels, and checklists suites.