### PR TITLE
feat(terraform): add OAuth callback URLs management in secrets

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -47,12 +47,16 @@ module "secrets" {
   resend_api_key                = var.resend_api_key
   google_client_id              = var.google_client_id
   google_client_secret          = var.google_client_secret
+  google_callback_url           = var.google_callback_url
   microsoft_client_id           = var.microsoft_client_id
   microsoft_client_secret       = var.microsoft_client_secret
+  microsoft_callback_url        = var.microsoft_callback_url
   apple_client_id               = var.apple_client_id
   apple_client_secret           = var.apple_client_secret
+  apple_callback_url            = var.apple_callback_url
   slack_client_id               = var.slack_client_id
   slack_client_secret           = var.slack_client_secret
+  slack_callback_url            = var.slack_callback_url
   backend_service_account_email = module.service_accounts.backend_service_account_email
   labels                        = local.common_labels
 

--- a/terraform/modules/secrets/main.tf
+++ b/terraform/modules/secrets/main.tf
@@ -397,3 +397,150 @@ resource "google_secret_manager_secret_iam_member" "slack_client_secret_access" 
 
   depends_on = [google_secret_manager_secret.slack_client_secret]
 }
+
+# ===================================
+# OAuth Callback URLs
+# ===================================
+resource "google_secret_manager_secret" "google_callback_url" {
+  count = var.google_callback_url != "" ? 1 : 0
+
+  secret_id = "${var.project_id}-google-callback-url"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+
+  labels = var.labels
+}
+
+resource "google_secret_manager_secret_version" "google_callback_url_version" {
+  count = var.google_callback_url != "" ? 1 : 0
+
+  secret      = google_secret_manager_secret.google_callback_url[0].id
+  secret_data = var.google_callback_url
+
+  depends_on = [google_secret_manager_secret.google_callback_url]
+
+  lifecycle {
+    ignore_changes = [secret_data]
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "google_callback_url_access" {
+  count = var.google_callback_url != "" ? 1 : 0
+
+  secret_id = google_secret_manager_secret.google_callback_url[0].id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${var.backend_service_account_email}"
+
+  depends_on = [google_secret_manager_secret.google_callback_url]
+}
+
+resource "google_secret_manager_secret" "microsoft_callback_url" {
+  count = var.microsoft_callback_url != "" ? 1 : 0
+
+  secret_id = "${var.project_id}-microsoft-callback-url"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+
+  labels = var.labels
+}
+
+resource "google_secret_manager_secret_version" "microsoft_callback_url_version" {
+  count = var.microsoft_callback_url != "" ? 1 : 0
+
+  secret      = google_secret_manager_secret.microsoft_callback_url[0].id
+  secret_data = var.microsoft_callback_url
+
+  depends_on = [google_secret_manager_secret.microsoft_callback_url]
+
+  lifecycle {
+    ignore_changes = [secret_data]
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "microsoft_callback_url_access" {
+  count = var.microsoft_callback_url != "" ? 1 : 0
+
+  secret_id = google_secret_manager_secret.microsoft_callback_url[0].id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${var.backend_service_account_email}"
+
+  depends_on = [google_secret_manager_secret.microsoft_callback_url]
+}
+
+resource "google_secret_manager_secret" "apple_callback_url" {
+  count = var.apple_callback_url != "" ? 1 : 0
+
+  secret_id = "${var.project_id}-apple-callback-url"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+
+  labels = var.labels
+}
+
+resource "google_secret_manager_secret_version" "apple_callback_url_version" {
+  count = var.apple_callback_url != "" ? 1 : 0
+
+  secret      = google_secret_manager_secret.apple_callback_url[0].id
+  secret_data = var.apple_callback_url
+
+  depends_on = [google_secret_manager_secret.apple_callback_url]
+
+  lifecycle {
+    ignore_changes = [secret_data]
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "apple_callback_url_access" {
+  count = var.apple_callback_url != "" ? 1 : 0
+
+  secret_id = google_secret_manager_secret.apple_callback_url[0].id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${var.backend_service_account_email}"
+
+  depends_on = [google_secret_manager_secret.apple_callback_url]
+}
+
+resource "google_secret_manager_secret" "slack_callback_url" {
+  count = var.slack_callback_url != "" ? 1 : 0
+
+  secret_id = "${var.project_id}-slack-callback-url"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+
+  labels = var.labels
+}
+
+resource "google_secret_manager_secret_version" "slack_callback_url_version" {
+  count = var.slack_callback_url != "" ? 1 : 0
+
+  secret      = google_secret_manager_secret.slack_callback_url[0].id
+  secret_data = var.slack_callback_url
+
+  depends_on = [google_secret_manager_secret.slack_callback_url]
+
+  lifecycle {
+    ignore_changes = [secret_data]
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "slack_callback_url_access" {
+  count = var.slack_callback_url != "" ? 1 : 0
+
+  secret_id = google_secret_manager_secret.slack_callback_url[0].id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${var.backend_service_account_email}"
+
+  depends_on = [google_secret_manager_secret.slack_callback_url]
+}

--- a/terraform/modules/secrets/variables.tf
+++ b/terraform/modules/secrets/variables.tf
@@ -93,6 +93,30 @@ variable "slack_client_secret" {
   default     = ""
 }
 
+variable "google_callback_url" {
+  description = "Google OAuth callback URL"
+  type        = string
+  default     = ""
+}
+
+variable "microsoft_callback_url" {
+  description = "Microsoft OAuth callback URL"
+  type        = string
+  default     = ""
+}
+
+variable "apple_callback_url" {
+  description = "Apple OAuth callback URL"
+  type        = string
+  default     = ""
+}
+
+variable "slack_callback_url" {
+  description = "Slack OAuth callback URL"
+  type        = string
+  default     = ""
+}
+
 variable "labels" {
   description = "Labels to apply to resources"
   type        = map(string)

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -196,6 +196,37 @@ variable "slack_client_secret" {
   default     = ""
 }
 
+# ===================================
+# OAuth Callback URLs (optional)
+# ===================================
+variable "google_callback_url" {
+  description = "Google OAuth callback URL. Format: https://{backend-url}/auth/google/callback. Can be left empty and set manually after first deployment using terraform output backend_url."
+  type        = string
+  sensitive   = false
+  default     = ""
+}
+
+variable "microsoft_callback_url" {
+  description = "Microsoft OAuth callback URL. Format: https://{backend-url}/auth/microsoft/callback. Can be left empty and set manually after first deployment using terraform output backend_url."
+  type        = string
+  sensitive   = false
+  default     = ""
+}
+
+variable "apple_callback_url" {
+  description = "Apple OAuth callback URL. Format: https://{backend-url}/auth/apple/callback. Can be left empty and set manually after first deployment using terraform output backend_url."
+  type        = string
+  sensitive   = false
+  default     = ""
+}
+
+variable "slack_callback_url" {
+  description = "Slack OAuth callback URL. Format: https://{backend-url}/auth/slack/callback. Can be left empty and set manually after first deployment using terraform output backend_url."
+  type        = string
+  sensitive   = false
+  default     = ""
+}
+
 
 # ===================================
 # Frontend (Cloud Run) Configuration


### PR DESCRIPTION
- Add variables for OAuth callback URLs (Google, Microsoft, Apple, Slack)
- Create secrets in Secret Manager for each callback URL
- Configure IAM permissions for backend service account access
- Callback URLs can be defined in .tfvars files after first deployment