### PR TITLE
feat: add FRONTEND_URL to CI/CD workflows and Terraform

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -494,17 +494,41 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
+      - name: Get Frontend URL
+        id: frontend-url
+        shell: bash
+        run: |
+          ENV=${{ needs.changes.outputs.environment }}
+          SERVICE_NAME="${ENV}-epitrello-frontend"
+          URL=$(gcloud run services describe $SERVICE_NAME \
+            --region ${{ env.GCP_REGION }} \
+            --project ${{ secrets.GCP_PROJECT_ID }} \
+            --format="value(status.url)" 2>/dev/null || echo "")
+          echo "url=$URL" >> $GITHUB_OUTPUT
+          echo "Frontend URL: $URL"
+
       - name: Deploy to Cloud Run
         run: |
           ENV=${{ needs.changes.outputs.environment }}
           IMAGE_TAG="${{ github.ref_name }}-${{ github.sha }}"
           IMAGE="gcr.io/${{ secrets.GCP_PROJECT_ID }}/epitrello-backend:${IMAGE_TAG}"
           SERVICE_NAME="${ENV}-epitrello-backend"
+          FRONTEND_URL="${{ steps.frontend-url.outputs.url }}"
 
-          gcloud run services update $SERVICE_NAME \
-            --image $IMAGE \
-            --region ${{ env.GCP_REGION }} \
-            --platform managed
+          if [ -n "$FRONTEND_URL" ]; then
+            echo "Updating backend with frontend URL: $FRONTEND_URL"
+            gcloud run services update $SERVICE_NAME \
+              --image $IMAGE \
+              --update-env-vars FRONTEND_URL=$FRONTEND_URL \
+              --region ${{ env.GCP_REGION }} \
+              --platform managed
+          else
+            echo "Warning: Frontend URL not available, deploying without FRONTEND_URL update"
+            gcloud run services update $SERVICE_NAME \
+              --image $IMAGE \
+              --region ${{ env.GCP_REGION }} \
+              --platform managed
+          fi
 
   deploy-frontend:
     name: Deploy Frontend to Cloud Run
@@ -536,6 +560,19 @@ jobs:
           production_api_url: ${{ secrets.PRODUCTION_API_URL }}
           staging_api_url: ${{ secrets.STAGING_API_URL }}
 
+      - name: Get Frontend URL
+        id: frontend-url
+        shell: bash
+        run: |
+          ENV=${{ needs.changes.outputs.environment }}
+          SERVICE_NAME="${ENV}-epitrello-frontend"
+          URL=$(gcloud run services describe $SERVICE_NAME \
+            --region ${{ env.GCP_REGION }} \
+            --project ${{ secrets.GCP_PROJECT_ID }} \
+            --format="value(status.url)" 2>/dev/null || echo "")
+          echo "url=$URL" >> $GITHUB_OUTPUT
+          echo "Frontend URL: $URL"
+
       - name: Deploy to Cloud Run
         run: |
           ENV=${{ needs.changes.outputs.environment }}
@@ -549,6 +586,22 @@ jobs:
             --update-env-vars NEXT_PUBLIC_API_URL=$BACKEND_URL \
             --region ${{ env.GCP_REGION }} \
             --platform managed
+
+      - name: Update Backend with Frontend URL
+        run: |
+          ENV=${{ needs.changes.outputs.environment }}
+          BACKEND_SERVICE_NAME="${ENV}-epitrello-backend"
+          FRONTEND_URL="${{ steps.frontend-url.outputs.url }}"
+
+          if [ -n "$FRONTEND_URL" ]; then
+            echo "Updating backend with frontend URL: $FRONTEND_URL"
+            gcloud run services update $BACKEND_SERVICE_NAME \
+              --update-env-vars FRONTEND_URL=$FRONTEND_URL \
+              --region ${{ env.GCP_REGION }} \
+              --platform managed
+          else
+            echo "Warning: Frontend URL not available, skipping backend update"
+          fi
 
   deploy-docs:
     name: Deploy GraphQL Documentation

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -29,19 +29,67 @@ async function bootstrap() {
 
     /**
      * Enable CORS.
-     * origin: process.env.FRONTEND_URL || 'http://localhost:3000' - The origin of the request.
-     * credentials: true - Allow credentials.
+     * Supports CORS_ORIGINS environment variable (comma-separated, supports wildcards like *.run.app)
+     * Falls back to FRONTEND_URL if CORS_ORIGINS is not set.
+     * In development, reflects the request origin (origin: true).
      */
-    // Enable CORS. In development reflect the request origin (origin: true)
-    // so the Access-Control-Allow-Origin header is set dynamically. In
-    // production, restrict to configured frontends.
     const isProduction = process.env.NODE_ENV === 'production';
     const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
     const backendPort = process.env.PORT || '8080';
+    const corsOrigins = process.env.CORS_ORIGINS;
 
-    const allowedOrigins = isProduction
-      ? [frontendUrl, `http://localhost:${backendPort}`]
-      : true; // reflect request origin in dev
+    const matchesWildcard = (origin: string, pattern: string): boolean => {
+      if (pattern === origin) return true;
+      if (!pattern.includes('*')) return false;
+
+      const regexPattern = pattern
+        .replace(/\./g, '\\.')
+        .replace(/\*/g, '.*');
+      const regex = new RegExp(`^${regexPattern}$`);
+      return regex.test(origin);
+    };
+
+    let allowedOrigins: string[] | boolean | ((origin: string, callback: (err: Error | null, allow?: boolean) => void) => void);
+
+    if (isProduction) {
+      if (corsOrigins) {
+        // Parse CORS_ORIGINS (comma-separated, supports wildcards)
+        const origins = corsOrigins.split(',').map((o) => o.trim()).filter(Boolean);
+        logger.log(`CORS origins configured: ${origins.join(', ')}`);
+
+        // Create a function that checks against both exact matches and wildcards
+        allowedOrigins = (origin: string, callback: (err: Error | null, allow?: boolean) => void) => {
+          if (!origin) {
+            callback(null, false);
+            return;
+          }
+
+          // Check exact matches first
+          if (origins.includes(origin)) {
+            logger.debug(`CORS: Origin ${origin} matched exactly`);
+            callback(null, true);
+            return;
+          }
+
+          // Check wildcard patterns
+          const matches = origins.some((pattern) => matchesWildcard(origin, pattern));
+          if (matches) {
+            logger.debug(`CORS: Origin ${origin} matched wildcard pattern`);
+          } else {
+            logger.warn(`CORS: Origin ${origin} not allowed. Allowed patterns: ${origins.join(', ')}`);
+          }
+          callback(null, matches);
+        };
+      } else {
+        // Fallback to FRONTEND_URL if CORS_ORIGINS is not set
+        logger.log(`CORS: Using FRONTEND_URL fallback: ${frontendUrl}`);
+        allowedOrigins = [frontendUrl, `http://localhost:${backendPort}`];
+      }
+    } else {
+      // In development, reflect request origin
+      logger.log('CORS: Development mode - reflecting request origin');
+      allowedOrigins = true;
+    }
 
     app.enableCors({
       origin: allowedOrigins,

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -149,6 +149,7 @@ module "cloud_run" {
   slack_client_secret_secret_name     = module.secrets.slack_client_secret_secret_name
   storage_bucket                      = module.cloud_storage.bucket_name
   vpc_connector_id                    = var.enable_private_ip ? module.networking.vpc_connector_id : null
+  frontend_url                        = "" # Will be updated via gcloud after frontend deployment
 
   labels = local.common_labels
 

--- a/terraform/modules/cloud-run/main.tf
+++ b/terraform/modules/cloud-run/main.tf
@@ -214,6 +214,15 @@ resource "google_cloud_run_v2_service" "backend" {
         value = "https://*.run.app"
       }
 
+      # Frontend URL (for OAuth redirects and email links)
+      dynamic "env" {
+        for_each = var.frontend_url != null && var.frontend_url != "" ? [1] : []
+        content {
+          name  = "FRONTEND_URL"
+          value = var.frontend_url
+        }
+      }
+
       # ===================================
       # Health Checks
       # ===================================

--- a/terraform/modules/cloud-run/variables.tf
+++ b/terraform/modules/cloud-run/variables.tf
@@ -124,6 +124,12 @@ variable "service_account_email" {
   type        = string
 }
 
+variable "frontend_url" {
+  description = "Frontend URL for CORS and OAuth redirects (optional, can be set after first deployment)"
+  type        = string
+  default     = ""
+}
+
 variable "labels" {
   description = "Labels to apply to resources"
   type        = map(string)


### PR DESCRIPTION
- Add frontend_url variable to Terraform cloud-run module
- Automatically configure FRONTEND_URL in GitHub Actions workflows
- Automatically update backend with frontend URL after deployment
- Support CORS_ORIGINS with wildcards in backend for dynamic Cloud Run URLs