### PR TITLE
fix: correct DataLoader mocks in dataloader tests

### DIFF
--- a/backend/src/modules/attachments/dataloaders/attachments.dataloader.spec.ts
+++ b/backend/src/modules/attachments/dataloaders/attachments.dataloader.spec.ts
@@ -1,12 +1,12 @@
 import { AttachmentsDataLoader } from './attachments.dataloader';
 import { PrismaService } from '../../../prisma/prisma.service';
 
-jest.mock('dataloader', () => ({
-  __esModule: true,
-  default: jest.fn().mockImplementation((batchFn) => ({
-    loadMany: (keys: readonly string[]) => Promise.resolve(batchFn(keys)),
-  })),
-}));
+jest.mock('dataloader', () => {
+  return jest.fn().mockImplementation((batchFn) => ({
+    load: jest.fn((key: string) => Promise.resolve(batchFn([key])[0])),
+    loadMany: jest.fn((keys: readonly string[]) => Promise.resolve(batchFn(keys))),
+  }));
+});
 
 describe('AttachmentsDataLoader', () => {
   let dataloader: AttachmentsDataLoader;

--- a/backend/src/modules/cards/dataloaders/cards.dataloader.spec.ts
+++ b/backend/src/modules/cards/dataloaders/cards.dataloader.spec.ts
@@ -1,12 +1,12 @@
 import { CardsDataLoader } from './cards.dataloader';
 import { PrismaService } from '../../../prisma/prisma.service';
 
-jest.mock('dataloader', () => ({
-  __esModule: true,
-  default: jest.fn().mockImplementation((batchFn) => ({
-    loadMany: (keys: readonly string[]) => Promise.resolve(batchFn(keys)),
-  })),
-}));
+jest.mock('dataloader', () => {
+  return jest.fn().mockImplementation((batchFn) => ({
+    load: jest.fn((key: string) => Promise.resolve(batchFn([key])[0])),
+    loadMany: jest.fn((keys: readonly string[]) => Promise.resolve(batchFn(keys))),
+  }));
+});
 
 describe('CardsDataLoader', () => {
   let dataloader: CardsDataLoader;

--- a/backend/src/modules/comments/dataloaders/comments.dataloader.spec.ts
+++ b/backend/src/modules/comments/dataloaders/comments.dataloader.spec.ts
@@ -1,12 +1,12 @@
 import { CommentsDataLoader } from './comments.dataloader';
 import { PrismaService } from '../../../prisma/prisma.service';
 
-jest.mock('dataloader', () => ({
-  __esModule: true,
-  default: jest.fn().mockImplementation((batchFn) => ({
-    loadMany: (keys: readonly string[]) => Promise.resolve(batchFn(keys)),
-  })),
-}));
+jest.mock('dataloader', () => {
+  return jest.fn().mockImplementation((batchFn) => ({
+    load: jest.fn((key: string) => Promise.resolve(batchFn([key])[0])),
+    loadMany: jest.fn((keys: readonly string[]) => Promise.resolve(batchFn(keys))),
+  }));
+});
 
 describe('CommentsDataLoader', () => {
   let dataloader: CommentsDataLoader;


### PR DESCRIPTION
- Fix DataLoader mock to work with CommonJS require syntax
- Update comments, attachments, and cards dataloader tests
- Ensure mocks properly implement DataLoader constructor