### PR TITLE
feat: configure OAuth callback URLs for GCP backend

### DIFF
--- a/.github/actions/setup-terraform-vars/action.yml
+++ b/.github/actions/setup-terraform-vars/action.yml
@@ -51,6 +51,18 @@ inputs:
   slack_client_secret:
     description: 'Slack OAuth client secret'
     required: false
+  google_callback_url:
+    description: 'Google OAuth callback URL'
+    required: false
+  microsoft_callback_url:
+    description: 'Microsoft OAuth callback URL'
+    required: false
+  apple_callback_url:
+    description: 'Apple OAuth callback URL'
+    required: false
+  slack_callback_url:
+    description: 'Slack OAuth callback URL'
+    required: false
   deployer_service_account_email:
     description: 'Deployer service account email for CI/CD (for documentation bucket permissions)'
     required: false
@@ -82,6 +94,19 @@ runs:
           -var="slack_client_id=${{ inputs.slack_client_id }}"
           -var="slack_client_secret=${{ inputs.slack_client_secret }}"
         )
+        # Add OAuth callback URLs if provided
+        if [ -n "${{ inputs.google_callback_url }}" ]; then
+          TF_VARS+=(-var="google_callback_url=${{ inputs.google_callback_url }}")
+        fi
+        if [ -n "${{ inputs.microsoft_callback_url }}" ]; then
+          TF_VARS+=(-var="microsoft_callback_url=${{ inputs.microsoft_callback_url }}")
+        fi
+        if [ -n "${{ inputs.apple_callback_url }}" ]; then
+          TF_VARS+=(-var="apple_callback_url=${{ inputs.apple_callback_url }}")
+        fi
+        if [ -n "${{ inputs.slack_callback_url }}" ]; then
+          TF_VARS+=(-var="slack_callback_url=${{ inputs.slack_callback_url }}")
+        fi
         # Add deployer_service_account_email if provided
         if [ -n "${{ inputs.deployer_service_account_email }}" ]; then
           TF_VARS+=(-var="deployer_service_account_email=${{ inputs.deployer_service_account_email }}")

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -309,6 +309,16 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
+      - name: Get Backend URL for callback URLs
+        id: backend-url-callbacks
+        uses: ./.github/actions/get-backend-url
+        with:
+          environment: ${{ needs.changes.outputs.environment }}
+          region: ${{ env.GCP_REGION }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          production_api_url: ${{ secrets.PRODUCTION_API_URL }}
+          staging_api_url: ${{ secrets.STAGING_API_URL }}
+
       - name: Terraform Init
         working-directory: ${{ env.TF_WORKING_DIR }}
         run: terraform init -upgrade
@@ -332,6 +342,10 @@ jobs:
           apple_client_secret: ${{ secrets.APPLE_CLIENT_SECRET }}
           slack_client_id: ${{ secrets.SLACK_CLIENT_ID }}
           slack_client_secret: ${{ secrets.SLACK_CLIENT_SECRET }}
+          google_callback_url: ${{ steps.backend-url-callbacks.outputs.url }}/auth/google/callback
+          microsoft_callback_url: ${{ steps.backend-url-callbacks.outputs.url }}/auth/microsoft/callback
+          apple_callback_url: ${{ steps.backend-url-callbacks.outputs.url }}/auth/apple/callback
+          slack_callback_url: ${{ steps.backend-url-callbacks.outputs.url }}/auth/slack/callback
 
       - name: Terraform Plan
         working-directory: ${{ env.TF_WORKING_DIR }}
@@ -378,6 +392,16 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
+      - name: Get Backend URL for callback URLs
+        id: backend-url-callbacks
+        uses: ./.github/actions/get-backend-url
+        with:
+          environment: ${{ needs.changes.outputs.environment }}
+          region: ${{ env.GCP_REGION }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          production_api_url: ${{ secrets.PRODUCTION_API_URL }}
+          staging_api_url: ${{ secrets.STAGING_API_URL }}
+
       - name: Download plan
         uses: actions/download-artifact@v4
         with:
@@ -423,6 +447,10 @@ jobs:
           apple_client_secret: ${{ secrets.APPLE_CLIENT_SECRET }}
           slack_client_id: ${{ secrets.SLACK_CLIENT_ID }}
           slack_client_secret: ${{ secrets.SLACK_CLIENT_SECRET }}
+          google_callback_url: ${{ steps.backend-url-callbacks.outputs.url }}/auth/google/callback
+          microsoft_callback_url: ${{ steps.backend-url-callbacks.outputs.url }}/auth/microsoft/callback
+          apple_callback_url: ${{ steps.backend-url-callbacks.outputs.url }}/auth/apple/callback
+          slack_callback_url: ${{ steps.backend-url-callbacks.outputs.url }}/auth/slack/callback
 
       - name: Import existing Terraform state bucket if needed
         working-directory: ${{ env.TF_WORKING_DIR }}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -8,7 +8,7 @@ export default function LandingPage() {
   return (
     <div className="min-h-screen bg-background">
       {/* Header */}
-      <header className="border-b border-border">
+      <header>
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
             <div className="flex items-center gap-3">

--- a/frontend/components/CardModal.tsx
+++ b/frontend/components/CardModal.tsx
@@ -597,7 +597,9 @@ export default function CardModal({ card, listId, isOpen, onClose }: CardModalPr
           className="max-w-[768px] w-full max-h-[90vh] p-0 flex flex-col overflow-hidden"
           showCloseButton={false}
         >
-          {/* Header de la modale - fixe */}
+          <DialogTitle className="sr-only">{card.title}</DialogTitle>
+          <DialogDescription className="sr-only">Card details and actions</DialogDescription>
+
           <div className="p-6 border-b border-trello-border shrink-0">
             <div className="flex items-start justify-between gap-4">
               <div className="flex-1 min-w-0">
@@ -606,7 +608,6 @@ export default function CardModal({ card, listId, isOpen, onClose }: CardModalPr
                   <div className="flex-1 min-w-0">
                     {!isEditingTitle ? (
                       <h2
-                        id="modal-title"
                         className="text-xl font-semibold text-trello cursor-pointer hover:bg-trello-hover px-2 py-1 -mx-2 -my-1 rounded transition-colors"
                         onClick={() => setIsEditingTitle(true)}
                         title="Click to edit title"
@@ -644,13 +645,9 @@ export default function CardModal({ card, listId, isOpen, onClose }: CardModalPr
             </div>
           </div>
 
-          {/* Contenu de la modale avec scroll vertical interne */}
           <div className="p-6 overflow-y-auto flex-1 custom-scrollbar" style={{ minHeight: 0 }}>
-          {/* Layout 2 colonnes */}
           <div className="flex gap-6 flex-col lg:flex-row">
-            {/* Colonne gauche - Contenu principal (~70%) */}
             <div className="flex-1 lg:w-[70%] space-y-6">
-              {/* Labels */}
               {assignedLabels && assignedLabels.length > 0 && (
                 <div>
                   <h3 className="text-sm font-semibold text-trello mb-2">Labels</h3>
@@ -674,7 +671,6 @@ export default function CardModal({ card, listId, isOpen, onClose }: CardModalPr
                 </div>
               )}
 
-              {/* Members */}
               {assignedMembers && assignedMembers.length > 0 && (
                 <div>
                   <h3 className="text-sm font-semibold text-trello mb-2">Members</h3>

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -182,7 +182,7 @@ export default function Sidebar() {
       className={`transition-all duration-150 bg-trello-card-bg border-r border-trello-border ${collapsed ? "w-20" : "w-64"} h-screen flex flex-col shrink-0`}
       aria-label="Main sidebar"
     >
-      <div className="flex items-center justify-between p-3 border-b border-trello">
+      <div className="flex items-center justify-between p-3">
         <div className="flex items-center gap-2">
           <div className="h-8 w-8 rounded bg-trello-blue text-white flex items-center justify-center font-bold">E</div>
           {!collapsed && <h3 className="text-sm font-semibold text-trello">Epitrello</h3>}

--- a/frontend/components/Topbar.tsx
+++ b/frontend/components/Topbar.tsx
@@ -62,7 +62,6 @@ export default function Topbar() {
 
   const onSearch = (e?: React.FormEvent) => {
     if (e) e.preventDefault();
-    // simple client-side emit; integrate with search route later
     console.log("Search for", query);
     setSearchOpen(false);
   };
@@ -70,7 +69,6 @@ export default function Topbar() {
   const [createOpen, setCreateOpen] = useState(false);
 
   const createBoard = (payload?: { name?: string; workspaceId?: string; visibility?: string }) => {
-    // If called with payload (from modal), create board; otherwise open modal
     if (!payload) {
       setCreateOpen(true);
       return;
@@ -111,7 +109,6 @@ export default function Topbar() {
       localStorage.setItem('epitrello_boards', JSON.stringify(next));
       window.dispatchEvent(new Event('epitrello:boards-updated'));
 
-      // navigate to the newly created board page
       router.push(`/boards/${id}`);
     } catch (e) {
       console.error(e);
@@ -124,15 +121,13 @@ export default function Topbar() {
   }
 
   return (
-    <header className="w-full border-b bg-trello-card-bg">
+    <header className="w-full bg-trello-card-bg">
       <div className="max-w-7xl mx-auto px-4 py-2 flex items-center justify-between gap-4">
         <div className="flex items-center gap-3">
-          {/* mobile menu button - purely visual/hook for later */}
           <Button aria-label="Open menu" variant="ghost" size="icon" className="md:hidden">
             <Menu className="h-5 w-5" />
           </Button>
 
-          {/* Logo / title */}
           <a href="/dashboard" className="flex items-center gap-2 no-underline">
             <div className="h-8 w-8 rounded flex items-center justify-center bg-trello-blue text-white font-bold">E</div>
             <span className="hidden sm:inline font-semibold text-trello">Epitrello</span>
@@ -257,7 +252,6 @@ export default function Topbar() {
                     variant="ghost"
                     onClick={(e) => {
                       e.preventDefault();
-                      // Clear client-side stored user data (client-only logout)
                       try {
                         localStorage.removeItem('epitrello_user');
                         localStorage.removeItem('epitrello_notifications');

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -149,7 +149,11 @@ module "cloud_run" {
   slack_client_secret_secret_name     = module.secrets.slack_client_secret_secret_name
   storage_bucket                      = module.cloud_storage.bucket_name
   vpc_connector_id                    = var.enable_private_ip ? module.networking.vpc_connector_id : null
-  frontend_url                        = "" # Will be updated via gcloud after frontend deployment
+  frontend_url                        = ""
+  google_callback_url                 = var.google_callback_url != "" ? var.google_callback_url : null
+  microsoft_callback_url              = var.microsoft_callback_url != "" ? var.microsoft_callback_url : null
+  apple_callback_url                  = var.apple_callback_url != "" ? var.apple_callback_url : null
+  slack_callback_url                  = var.slack_callback_url != "" ? var.slack_callback_url : null
 
   labels = local.common_labels
 

--- a/terraform/modules/cloud-run/main.tf
+++ b/terraform/modules/cloud-run/main.tf
@@ -105,6 +105,42 @@ resource "google_cloud_run_v2_service" "backend" {
         }
       }
 
+      # Google OAuth Callback URL
+      dynamic "env" {
+        for_each = var.google_callback_url != null && var.google_callback_url != "" ? [1] : []
+        content {
+          name  = "GOOGLE_CALLBACK_URL"
+          value = var.google_callback_url
+        }
+      }
+
+      # Microsoft OAuth Callback URL
+      dynamic "env" {
+        for_each = var.microsoft_callback_url != null && var.microsoft_callback_url != "" ? [1] : []
+        content {
+          name  = "MICROSOFT_CALLBACK_URL"
+          value = var.microsoft_callback_url
+        }
+      }
+
+      # Apple OAuth Callback URL
+      dynamic "env" {
+        for_each = var.apple_callback_url != null && var.apple_callback_url != "" ? [1] : []
+        content {
+          name  = "APPLE_CALLBACK_URL"
+          value = var.apple_callback_url
+        }
+      }
+
+      # Slack OAuth Callback URL
+      dynamic "env" {
+        for_each = var.slack_callback_url != null && var.slack_callback_url != "" ? [1] : []
+        content {
+          name  = "SLACK_CALLBACK_URL"
+          value = var.slack_callback_url
+        }
+      }
+
       # Microsoft OAuth from Secret Manager (optional)
       dynamic "env" {
         for_each = var.microsoft_client_id_secret_name != null ? [1] : []
@@ -208,10 +244,10 @@ resource "google_cloud_run_v2_service" "backend" {
         value = "false"
       }
 
-      # CORS origins
+      # CORS origins (includes localhost for local development)
       env {
         name  = "CORS_ORIGINS"
-        value = "https://*.run.app"
+        value = "https://*.run.app,http://localhost:3000"
       }
 
       # Frontend URL (for OAuth redirects and email links)

--- a/terraform/modules/cloud-run/variables.tf
+++ b/terraform/modules/cloud-run/variables.tf
@@ -108,6 +108,30 @@ variable "slack_client_secret_secret_name" {
   default     = null
 }
 
+variable "google_callback_url" {
+  description = "Google OAuth callback URL (optional)"
+  type        = string
+  default     = null
+}
+
+variable "microsoft_callback_url" {
+  description = "Microsoft OAuth callback URL (optional)"
+  type        = string
+  default     = null
+}
+
+variable "apple_callback_url" {
+  description = "Apple OAuth callback URL (optional)"
+  type        = string
+  default     = null
+}
+
+variable "slack_callback_url" {
+  description = "Slack OAuth callback URL (optional)"
+  type        = string
+  default     = null
+}
+
 variable "storage_bucket" {
   description = "Cloud Storage bucket name"
   type        = string


### PR DESCRIPTION
- Add callback URL environment variables to Cloud Run module
- Update Terraform to pass callback URLs from variables
- Configure CI/CD to automatically set callback URLs from backend URL
- Update setup-terraform-vars action to support callback URLs
- Fix CORS to allow localhost:3000 for local development