### PR TITLE
test(backend): couverture patch ws-auth, board-subscription, gql-auth…

### DIFF
--- a/backend/src/common/guards/gql-auth.guard.spec.ts
+++ b/backend/src/common/guards/gql-auth.guard.spec.ts
@@ -85,6 +85,30 @@ describe('GqlAuthGuard', () => {
       await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow('Auth failed');
       expect(Logger.prototype.warn).toHaveBeenCalled();
     });
+
+    it('should return true when req.user is set (subscription / pre-authenticated context)', async () => {
+      const mockUser = { id: 'user-1', email: 'test@example.com' };
+      const mockRequest = { user: mockUser };
+      const mockExecutionContext = {
+        getHandler: jest.fn(),
+        getClass: jest.fn(),
+        getType: jest.fn().mockReturnValue('http'),
+        switchToHttp: jest.fn().mockReturnValue({ getRequest: () => mockRequest }),
+      } as unknown as ExecutionContext;
+
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+      const parentPrototype = Object.getPrototypeOf(GqlAuthGuard.prototype) as { canActivate: (c: ExecutionContext) => Promise<boolean> };
+      const parentSpy = jest.spyOn(parentPrototype, 'canActivate');
+      parentSpy.mockClear();
+
+      const result = await guard.canActivate(mockExecutionContext);
+
+      expect(result).toBe(true);
+      expect(Logger.prototype.debug).toHaveBeenCalledWith(
+        'Subscription or pre-authenticated context',
+      );
+      expect(parentSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('getRequest', () => {
@@ -119,6 +143,9 @@ describe('GqlAuthGuard', () => {
       const result = guard.getRequest(mockExecutionContext);
 
       expect(result).toEqual(mockRequest);
+      expect(Logger.prototype.debug).toHaveBeenCalledWith(
+        'Authentication attempt with Bearer token',
+      );
     });
 
     it('should log when no authorization header is present', () => {

--- a/backend/src/common/subscriptions/README.md
+++ b/backend/src/common/subscriptions/README.md
@@ -4,7 +4,12 @@ Real-time collaboration is provided via **GraphQL Subscriptions** over WebSocket
 
 ## Setup summary
 
-| Requirement | Implementation |
+| Requirement | Implementation |Set up WebSocket support for real-time collaboration.
+
+    Add WebSocket gateway (NestJS @WebSocketGateway) or GraphQL Subscriptions
+    Authenticate connections (JWT / cookie) and associate the user
+    Define rooms/channels per board (or per card) to target events
+
 |-------------|----------------|
 | **WebSocket** | GraphQL Subscriptions with `graphql-ws` (same URL as `/graphql`) |
 | **Authentication** | JWT in connection params; `onConnect` validates token and attaches user; unauthenticated connections are rejected |

--- a/backend/src/common/subscriptions/ws-auth.spec.ts
+++ b/backend/src/common/subscriptions/ws-auth.spec.ts
@@ -1,0 +1,205 @@
+import { JwtService } from '@nestjs/jwt';
+import { Logger } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { validateWsConnection } from './ws-auth';
+
+describe('validateWsConnection', () => {
+  let jwtService: JwtService;
+  let prisma: PrismaService;
+
+  const mockUser = {
+    id: 'user-1',
+    email: 'test@example.com',
+    name: 'Test User',
+    avatar: 'https://example.com/avatar.png',
+  };
+
+  beforeEach(() => {
+    jwtService = {
+      verifyAsync: jest.fn(),
+    } as unknown as JwtService;
+    prisma = {
+      user: {
+        findUnique: jest.fn(),
+      },
+    } as unknown as PrismaService;
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should return null when no token in connectionParams', async () => {
+    const result = await validateWsConnection({}, jwtService, prisma);
+    expect(result).toBeNull();
+    expect(Logger.prototype.debug).toHaveBeenCalledWith(
+      'WebSocket connection: no token in connectionParams',
+    );
+  });
+
+  it('should return null when Authorization is undefined and authToken is undefined', async () => {
+    const result = await validateWsConnection(
+      { someKey: 'value' },
+      jwtService,
+      prisma,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('should return null when raw is not a string', async () => {
+    const result = await validateWsConnection(
+      { Authorization: 123 as unknown as string },
+      jwtService,
+      prisma,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('should return null when token is empty after stripping Bearer', async () => {
+    const result = await validateWsConnection(
+      { Authorization: 'Bearer ' },
+      jwtService,
+      prisma,
+    );
+    expect(result).toBeNull();
+    expect(jwtService.verifyAsync).not.toHaveBeenCalled();
+  });
+
+  it('should extract token from Bearer Authorization and return user', async () => {
+    (jwtService.verifyAsync as jest.Mock).mockResolvedValue({ userId: 'user-1' });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+
+    const result = await validateWsConnection(
+      { Authorization: 'Bearer my-jwt-token' },
+      jwtService,
+      prisma,
+    );
+
+    expect(result).toEqual({
+      id: 'user-1',
+      userId: 'user-1',
+      email: 'test@example.com',
+      name: 'Test User',
+      avatar: 'https://example.com/avatar.png',
+    });
+    expect(jwtService.verifyAsync).toHaveBeenCalledWith('my-jwt-token');
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      select: { id: true, email: true, name: true, avatar: true },
+    });
+  });
+
+  it('should use authToken when Authorization is not set', async () => {
+    (jwtService.verifyAsync as jest.Mock).mockResolvedValue({ userId: 'user-1' });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+
+    const result = await validateWsConnection(
+      { authToken: 'plain-token' },
+      jwtService,
+      prisma,
+    );
+
+    expect(result).not.toBeNull();
+    expect(jwtService.verifyAsync).toHaveBeenCalledWith('plain-token');
+  });
+
+  it('should use authorization (lowercase) when others not set', async () => {
+    (jwtService.verifyAsync as jest.Mock).mockResolvedValue({ sub: 'user-1' });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+
+    const result = await validateWsConnection(
+      { authorization: 'Bearer lower-token' },
+      jwtService,
+      prisma,
+    );
+
+    expect(result).not.toBeNull();
+    expect(jwtService.verifyAsync).toHaveBeenCalledWith('lower-token');
+  });
+
+  it('should use sub when userId is not in payload', async () => {
+    (jwtService.verifyAsync as jest.Mock).mockResolvedValue({ sub: 'user-1' });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+
+    const result = await validateWsConnection(
+      { authToken: 'token' },
+      jwtService,
+      prisma,
+    );
+
+    expect(result?.userId).toBe('user-1');
+    expect(prisma.user.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'user-1' } }),
+    );
+  });
+
+  it('should return null when payload has no userId nor sub', async () => {
+    (jwtService.verifyAsync as jest.Mock).mockResolvedValue({});
+
+    const result = await validateWsConnection(
+      { authToken: 'token' },
+      jwtService,
+      prisma,
+    );
+
+    expect(result).toBeNull();
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('should return null when user not found in database', async () => {
+    (jwtService.verifyAsync as jest.Mock).mockResolvedValue({ userId: 'user-1' });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const result = await validateWsConnection(
+      { authToken: 'token' },
+      jwtService,
+      prisma,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when verifyAsync throws (invalid token)', async () => {
+    (jwtService.verifyAsync as jest.Mock).mockRejectedValue(new Error('jwt expired'));
+
+    const result = await validateWsConnection(
+      { authToken: 'bad-token' },
+      jwtService,
+      prisma,
+    );
+
+    expect(result).toBeNull();
+    expect(Logger.prototype.debug).toHaveBeenCalledWith(
+      'WebSocket auth failed: jwt expired',
+    );
+  });
+
+  it('should return null and log "invalid token" when throw is not Error', async () => {
+    (jwtService.verifyAsync as jest.Mock).mockRejectedValue('string error');
+
+    const result = await validateWsConnection(
+      { authToken: 'token' },
+      jwtService,
+      prisma,
+    );
+
+    expect(result).toBeNull();
+    expect(Logger.prototype.debug).toHaveBeenCalledWith(
+      'WebSocket auth failed: invalid token',
+    );
+  });
+
+  it('should not add Bearer prefix when token already has it', async () => {
+    (jwtService.verifyAsync as jest.Mock).mockResolvedValue({ userId: 'user-1' });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+
+    await validateWsConnection(
+      { authToken: 'Bearer already-bearer' },
+      jwtService,
+      prisma,
+    );
+
+    expect(jwtService.verifyAsync).toHaveBeenCalledWith('already-bearer');
+  });
+});

--- a/backend/src/modules/boards/board-subscription.resolver.spec.ts
+++ b/backend/src/modules/boards/board-subscription.resolver.spec.ts
@@ -1,0 +1,128 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BoardSubscriptionResolver } from './board-subscription.resolver';
+import { PUB_SUB } from '../../common/subscriptions/pubsub.provider';
+import {
+  TRIGGER_CARD_UPDATED,
+  TRIGGER_LIST_UPDATED,
+  type CardUpdatedPayload,
+  type ListUpdatedPayload,
+} from './board-subscription.resolver';
+import { Card } from '../cards/entities/card.entity';
+import { List } from '../lists/entities/list.entity';
+
+describe('BoardSubscriptionResolver', () => {
+  let resolver: BoardSubscriptionResolver;
+  let pubSub: { asyncIterableIterator: jest.Mock };
+
+  const mockCard: Card = {
+    id: 'card-1',
+    listId: 'list-1',
+    title: 'Card',
+    description: null,
+    background: null,
+    startDate: null,
+    dueDate: null,
+    position: 0,
+    completed: false,
+    isArchived: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const mockList: List = {
+    id: 'list-1',
+    boardId: 'board-1',
+    title: 'List',
+    position: 0,
+    isArchived: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    const mockIterator = { [Symbol.asyncIterator]: jest.fn() };
+    pubSub = {
+      asyncIterableIterator: jest.fn().mockReturnValue(mockIterator),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BoardSubscriptionResolver,
+        {
+          provide: PUB_SUB,
+          useValue: pubSub,
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<BoardSubscriptionResolver>(BoardSubscriptionResolver);
+  });
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined();
+  });
+
+  describe('cardUpdated', () => {
+    it('should return async iterable for TRIGGER_CARD_UPDATED', () => {
+      const result = resolver.cardUpdated('board-1');
+      expect(pubSub.asyncIterableIterator).toHaveBeenCalledWith(TRIGGER_CARD_UPDATED);
+      expect(result).toBeDefined();
+      expect(typeof result[Symbol.asyncIterator]).toBe('function');
+    });
+  });
+
+  describe('listUpdated', () => {
+    it('should return async iterable for TRIGGER_LIST_UPDATED', () => {
+      const result = resolver.listUpdated('board-1');
+      expect(pubSub.asyncIterableIterator).toHaveBeenCalledWith(TRIGGER_LIST_UPDATED);
+      expect(result).toBeDefined();
+      expect(typeof result[Symbol.asyncIterator]).toBe('function');
+    });
+  });
+
+  describe('cardUpdatedByCardId', () => {
+    it('should return async iterable for TRIGGER_CARD_UPDATED', () => {
+      const result = resolver.cardUpdatedByCardId('card-1');
+      expect(pubSub.asyncIterableIterator).toHaveBeenCalledWith(TRIGGER_CARD_UPDATED);
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('subscription filter/resolve behavior', () => {
+    it('cardUpdated filter should pass when boardId matches', () => {
+      const payload: CardUpdatedPayload = { cardUpdated: mockCard, boardId: 'board-1' };
+      const filter = (p: CardUpdatedPayload, v: { boardId: string }) =>
+        p.boardId === v.boardId;
+      expect(filter(payload, { boardId: 'board-1' })).toBe(true);
+      expect(filter(payload, { boardId: 'board-2' })).toBe(false);
+    });
+
+    it('listUpdated filter should pass when boardId matches', () => {
+      const payload: ListUpdatedPayload = { listUpdated: mockList, boardId: 'board-1' };
+      const filter = (p: ListUpdatedPayload, v: { boardId: string }) =>
+        p.boardId === v.boardId;
+      expect(filter(payload, { boardId: 'board-1' })).toBe(true);
+      expect(filter(payload, { boardId: 'board-2' })).toBe(false);
+    });
+
+    it('cardUpdatedByCardId filter should pass when cardId matches', () => {
+      const payload: CardUpdatedPayload = { cardUpdated: mockCard, boardId: 'board-1' };
+      const filter = (p: CardUpdatedPayload, v: { cardId: string }) =>
+        p.cardUpdated.id === v.cardId;
+      expect(filter(payload, { cardId: 'card-1' })).toBe(true);
+      expect(filter(payload, { cardId: 'card-2' })).toBe(false);
+    });
+
+    it('cardUpdated resolve should return cardUpdated from payload', () => {
+      const payload: CardUpdatedPayload = { cardUpdated: mockCard, boardId: 'board-1' };
+      const resolve = (p: CardUpdatedPayload) => p.cardUpdated;
+      expect(resolve(payload)).toBe(mockCard);
+    });
+
+    it('listUpdated resolve should return listUpdated from payload', () => {
+      const payload: ListUpdatedPayload = { listUpdated: mockList, boardId: 'board-1' };
+      const resolve = (p: ListUpdatedPayload) => p.listUpdated;
+      expect(resolve(payload)).toBe(mockList);
+    });
+  });
+});


### PR DESCRIPTION
….guard

- ws-auth.spec.ts: validateWsConnection (token, Bearer, authToken, sub, erreurs)
- board-subscription.resolver.spec.ts: cardUpdated, listUpdated, cardUpdatedByCardId + filtres
- gql-auth.guard.spec: contexte pré-authentifié (req.user), log Bearer