### PR TITLE
feat(activity): board activity for all members, archive/unarchive eve…

### DIFF
--- a/backend/prisma/migrations/20260201000500_add_activity/migration.sql
+++ b/backend/prisma/migrations/20260201000500_add_activity/migration.sql
@@ -1,0 +1,31 @@
+-- CreateEnum
+CREATE TYPE "ActivityType" AS ENUM ('CARD_CREATED', 'CARD_COMPLETED', 'CARD_UNCOMPLETED', 'CARD_MOVED', 'COMMENT_ADDED', 'MEMBER_ADDED_TO_CARD', 'MEMBER_ADDED_TO_BOARD');
+
+-- CreateTable
+CREATE TABLE "activities" (
+    "id" TEXT NOT NULL,
+    "type" "ActivityType" NOT NULL,
+    "userId" TEXT NOT NULL,
+    "boardId" TEXT NOT NULL,
+    "cardId" TEXT,
+    "listId" TEXT,
+    "payload" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "activities_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "activities_userId_idx" ON "activities"("userId");
+
+-- CreateIndex
+CREATE INDEX "activities_boardId_idx" ON "activities"("boardId");
+
+-- CreateIndex
+CREATE INDEX "activities_userId_createdAt_idx" ON "activities"("userId", "createdAt" DESC);
+
+-- AddForeignKey
+ALTER TABLE "activities" ADD CONSTRAINT "activities_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activities" ADD CONSTRAINT "activities_boardId_fkey" FOREIGN KEY ("boardId") REFERENCES "boards"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20260201010358_add_activity_archive_types/migration.sql
+++ b/backend/prisma/migrations/20260201010358_add_activity_archive_types/migration.sql
@@ -1,0 +1,14 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "ActivityType" ADD VALUE 'CARD_ARCHIVED';
+ALTER TYPE "ActivityType" ADD VALUE 'CARD_UNARCHIVED';
+ALTER TYPE "ActivityType" ADD VALUE 'LIST_ARCHIVED';
+ALTER TYPE "ActivityType" ADD VALUE 'LIST_UNARCHIVED';
+ALTER TYPE "ActivityType" ADD VALUE 'BOARD_ARCHIVED';
+ALTER TYPE "ActivityType" ADD VALUE 'BOARD_UNARCHIVED';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -61,6 +61,22 @@ enum OAuthProvider {
   SLACK
 }
 
+enum ActivityType {
+  CARD_CREATED
+  CARD_COMPLETED
+  CARD_UNCOMPLETED
+  CARD_MOVED
+  COMMENT_ADDED
+  MEMBER_ADDED_TO_CARD
+  MEMBER_ADDED_TO_BOARD
+  CARD_ARCHIVED
+  CARD_UNARCHIVED
+  LIST_ARCHIVED
+  LIST_UNARCHIVED
+  BOARD_ARCHIVED
+  BOARD_UNARCHIVED
+}
+
 // ============================================================================
 // Core Models
 // ============================================================================
@@ -118,6 +134,7 @@ model User {
   oauthAccounts        OAuthAccount[]
   sentInvitations      WorkspaceInvitation[] @relation("InvitationInviter")
   receivedInvitations  WorkspaceInvitation[] @relation("InvitationInvitee")
+  activities           Activity[]
 
   @@map("users")
 }
@@ -143,12 +160,13 @@ model Board {
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
 
-  workspace Workspace?    @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
-  creatorId String
-  creator   User          @relation("BoardCreator", fields: [creatorId], references: [id], onDelete: Cascade)
-  members   BoardMember[]
-  lists     List[]
-  labels    Label[]
+  workspace  Workspace?    @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  creatorId  String
+  creator    User          @relation("BoardCreator", fields: [creatorId], references: [id], onDelete: Cascade)
+  members    BoardMember[]
+  lists      List[]
+  labels     Label[]
+  activities Activity[]
 
   @@map("boards")
 }
@@ -426,6 +444,30 @@ model OAuthAccount {
   @@unique([provider, providerId])
   @@index([userId])
   @@map("oauth_accounts")
+}
+
+// ----------------------------------------------------------------------------
+// Activity
+// ----------------------------------------------------------------------------
+// Represents a user action for the activity log (card completed, moved, comment added, etc.).
+
+model Activity {
+  id        String       @id @default(uuid())
+  type      ActivityType
+  userId    String
+  boardId   String
+  cardId    String?
+  listId    String?
+  payload   Json?
+  createdAt DateTime     @default(now())
+
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  board Board @relation(fields: [boardId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([boardId])
+  @@index([userId, createdAt(sort: Desc)])
+  @@map("activities")
 }
 
 // ----------------------------------------------------------------------------

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -19,6 +19,7 @@ import { LabelsModule } from './modules/labels/labels.module';
 import { ChecklistsModule } from './modules/checklists/checklists.module';
 import { CommentsModule } from './modules/comments/comments.module';
 import { AttachmentsModule } from './modules/attachments/attachments.module';
+import { ActivityModule } from './modules/activity/activity.module';
 import { SubscriptionsModule } from './common/subscriptions/subscriptions.module';
 import { validateWsConnection } from './common/subscriptions/ws-auth';
 import { GqlAuthGuard } from './common/guards/gql-auth.guard';
@@ -87,6 +88,7 @@ import { HealthController } from './common/controllers/health.controller';
     ChecklistsModule,
     CommentsModule,
     AttachmentsModule,
+    ActivityModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/backend/src/common/filters/http-exception.filter.spec.ts
+++ b/backend/src/common/filters/http-exception.filter.spec.ts
@@ -40,6 +40,30 @@ describe('AllExceptionsFilter', () => {
     expect((result as GraphQLError).message).toBe('Validation failed');
   });
 
+  it('should handle HTTP exception with array message in response', () => {
+    const exception = new HttpException(
+      { message: ['Error one', 'Error two'], error: 'Bad Request' },
+      HttpStatus.BAD_REQUEST,
+    );
+
+    const result = filter.catch(exception);
+
+    expect(result).toBeInstanceOf(GraphQLError);
+    expect((result as GraphQLError).message).toBe('Error one, Error two');
+  });
+
+  it('should handle HTTP exception with invalid message shape (fallback to Request failed)', () => {
+    const exception = new HttpException(
+      { message: 123, error: 'Bad Request' },
+      HttpStatus.BAD_REQUEST,
+    );
+
+    const result = filter.catch(exception);
+
+    expect(result).toBeInstanceOf(GraphQLError);
+    expect((result as GraphQLError).message).toBe('Request failed');
+  });
+
   it('should handle Prisma P2002 error', () => {
     const exception = { code: 'P2002', message: 'Unique constraint failed' };
 

--- a/backend/src/graphql/schema.gql
+++ b/backend/src/graphql/schema.gql
@@ -2,6 +2,45 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
 # ------------------------------------------------------
 
+type Activity {
+  board: Board
+  boardId: ID!
+  cardId: ID
+  createdAt: DateTime!
+  id: ID!
+  listId: ID
+  payload: ActivityPayload
+  type: ActivityType!
+  user: User
+  userId: ID!
+}
+
+type ActivityPayload {
+  boardTitle: String
+  cardTitle: String
+  commentPreview: String
+  listName: String
+  memberName: String
+  targetListName: String
+}
+
+"""Type of user action recorded in the activity log"""
+enum ActivityType {
+  BOARD_ARCHIVED
+  BOARD_UNARCHIVED
+  CARD_ARCHIVED
+  CARD_COMPLETED
+  CARD_CREATED
+  CARD_MOVED
+  CARD_UNARCHIVED
+  CARD_UNCOMPLETED
+  COMMENT_ADDED
+  LIST_ARCHIVED
+  LIST_UNARCHIVED
+  MEMBER_ADDED_TO_BOARD
+  MEMBER_ADDED_TO_CARD
+}
+
 input AddBoardMemberInput {
   boardId: ID!
   role: String
@@ -59,6 +98,12 @@ type Board {
   updatedAt: DateTime!
   visibility: Visibility!
   workspaceId: ID
+}
+
+input BoardActivityInput {
+  """Cursor for pagination (activity id)."""
+  cursor: ID
+  limit: Int = 50
 }
 
 type BoardMemberWithUser {
@@ -492,6 +537,25 @@ type Mutation {
   verifyEmail(token: String!): MessageResponse!
 }
 
+input MyActivityInput {
+  """Cursor for pagination (activity id). Fetch activities older than this."""
+  cursor: ID
+  limit: Int = 20
+
+  """
+  Filter by workspace IDs. Only activities from boards in these workspaces.
+  """
+  workspaceIds: [ID!]
+}
+
+type MyActivityResult {
+  activities: [Activity!]!
+  hasMore: Boolean!
+
+  """Cursor for next page (last activity id)"""
+  nextCursor: ID
+}
+
 type Query {
   """Get archived cards for a board. User must have access to the board."""
   archivedCards(boardId: ID!): [Card!]!
@@ -504,6 +568,11 @@ type Query {
 
   """Get a board by ID. Access based on visibility and membership."""
   board(id: ID!): Board!
+
+  """
+  Get activity for a board (all members). User must have access to the board.
+  """
+  boardActivity(boardId: String!, input: BoardActivityInput = {}): MyActivityResult!
 
   """List all labels for a board. User must have access to the board."""
   boardLabels(boardId: ID!): [Label!]!
@@ -531,6 +600,11 @@ type Query {
 
   """Get the currently authenticated user information"""
   me: User
+
+  """
+  Get current user activity log with optional workspace filter and pagination.
+  """
+  myActivity(input: MyActivityInput = {}): MyActivityResult!
 
   """Get all pending invitations for the current user."""
   myInvitations: [WorkspaceInvitation!]!

--- a/backend/src/modules/activity/activity.module.ts
+++ b/backend/src/modules/activity/activity.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../../prisma/prisma.module';
+import { ActivityService } from './activity.service';
+import { ActivityResolver } from './activity.resolver';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [ActivityService, ActivityResolver],
+  exports: [ActivityService],
+})
+export class ActivityModule {}

--- a/backend/src/modules/activity/activity.resolver.ts
+++ b/backend/src/modules/activity/activity.resolver.ts
@@ -1,0 +1,88 @@
+import { Resolver, Query, Args, ResolveField, Parent } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
+import DataLoader = require('dataloader');
+import { ActivityService } from './activity.service';
+import { Activity, MyActivityResult } from './entities/activity.entity';
+import { MyActivityInput } from './dto/my-activity.input';
+import { BoardActivityInput } from './dto/board-activity.input';
+import { GqlAuthGuard } from '../../common/guards/gql-auth.guard';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { User } from '../users/entities/user.entity';
+import { Board } from '../boards/entities/board.entity';
+import { PrismaService } from '../../prisma/prisma.service';
+
+@Resolver(() => Activity)
+@UseGuards(GqlAuthGuard)
+export class ActivityResolver {
+  private readonly userLoader: DataLoader<string, User | null>;
+  private readonly boardLoader: DataLoader<string, Board | null>;
+
+  constructor(
+    private readonly activityService: ActivityService,
+    private readonly prisma: PrismaService,
+  ) {
+    this.userLoader = new DataLoader<string, User | null>(async (ids) => {
+      const users = await this.prisma.user.findMany({
+        where: { id: { in: [...ids] } },
+      });
+      const map = new Map(users.map((u) => [u.id, u]));
+      return ids.map((id) => {
+        const u = map.get(id);
+        return u ? { ...u } : null;
+      });
+    });
+    this.boardLoader = new DataLoader<string, Board | null>(async (ids) => {
+      const boards = await this.prisma.board.findMany({
+        where: { id: { in: [...ids] } },
+      });
+      const map = new Map(boards.map((b) => [b.id, b]));
+      return ids.map((id) => {
+        const b = map.get(id);
+        return b ? { ...b } : null;
+      });
+    });
+  }
+
+  @Query(() => MyActivityResult, {
+    name: 'myActivity',
+    description: 'Get current user activity log with optional workspace filter and pagination.',
+  })
+  async myActivity(
+    @Args('input', { nullable: true, defaultValue: {} }) input: MyActivityInput | undefined,
+    @CurrentUser() user: { id: string },
+  ): Promise<MyActivityResult> {
+    const opts = {
+      limit: input?.limit ?? 20,
+      cursor: input?.cursor,
+      workspaceIds: input?.workspaceIds,
+    };
+    return this.activityService.findMyActivity(user.id, opts);
+  }
+
+  @Query(() => MyActivityResult, {
+    name: 'boardActivity',
+    description:
+      'Get activity for a board (all members). User must have access to the board.',
+  })
+  async boardActivity(
+    @Args('boardId', { type: () => String }) boardId: string,
+    @Args('input', { nullable: true, defaultValue: {} }) input: BoardActivityInput | undefined,
+    @CurrentUser() user: { id: string },
+  ): Promise<MyActivityResult> {
+    const opts = {
+      limit: input?.limit ?? 50,
+      cursor: input?.cursor,
+    };
+    return this.activityService.findBoardActivity(boardId, user.id, opts);
+  }
+
+  @ResolveField(() => User, { nullable: true })
+  async user(@Parent() activity: Activity): Promise<User | null> {
+    return this.userLoader.load(activity.userId);
+  }
+
+  @ResolveField(() => Board, { nullable: true })
+  async board(@Parent() activity: Activity): Promise<Board | null> {
+    return this.boardLoader.load(activity.boardId);
+  }
+}

--- a/backend/src/modules/activity/activity.service.ts
+++ b/backend/src/modules/activity/activity.service.ts
@@ -1,0 +1,164 @@
+import { Injectable, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { ActivityType as PrismaActivityType, Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import {
+  Activity,
+  ActivityPayload,
+  MyActivityResult,
+} from './entities/activity.entity';
+import { MyActivityInput } from './dto/my-activity.input';
+import { BoardActivityInput } from './dto/board-activity.input';
+
+export type CreateActivityData = {
+  type: PrismaActivityType;
+  userId: string;
+  boardId: string;
+  cardId?: string | null;
+  listId?: string | null;
+  payload?: Record<string, unknown> | null;
+};
+
+@Injectable()
+export class ActivityService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Record an activity entry. Used by cards, comments, boards resolvers.
+   */
+  async create(data: CreateActivityData): Promise<Activity> {
+    const row = await this.prisma.activity.create({
+      data: {
+        type: data.type,
+        userId: data.userId,
+        boardId: data.boardId,
+        cardId: data.cardId ?? undefined,
+        listId: data.listId ?? undefined,
+        payload: (data.payload ?? undefined) as Prisma.InputJsonValue | undefined,
+      },
+    });
+    return this.toActivity(row);
+  }
+
+  /**
+   * Get current user's activity with optional workspace filter and pagination.
+   */
+  async findMyActivity(userId: string, input: MyActivityInput): Promise<MyActivityResult> {
+    const limit = Math.min(input.limit ?? 20, 50);
+    const take = limit + 1;
+
+    const where: { userId: string; board?: { workspaceId: { in: string[] } | null } } = {
+      userId,
+    };
+
+    if (input.workspaceIds?.length) {
+      where.board = {
+        workspaceId: { in: input.workspaceIds },
+      };
+    }
+
+    const rows = await this.prisma.activity.findMany({
+      where,
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take,
+      skip: input.cursor ? 1 : 0,
+      cursor: input.cursor ? { id: input.cursor } : undefined,
+    });
+
+    const hasMore = rows.length > limit;
+    const activities = rows.slice(0, limit).map((r) => this.toActivity(r));
+    const nextCursor = hasMore && activities.length > 0 ? activities[activities.length - 1].id : null;
+
+    return {
+      activities,
+      hasMore,
+      nextCursor,
+    };
+  }
+
+  /**
+   * Get activity for a board (all members). User must have access to the board.
+   */
+  async findBoardActivity(
+    boardId: string,
+    userId: string,
+    input: BoardActivityInput,
+  ): Promise<MyActivityResult> {
+    const board = await this.prisma.board.findUnique({
+      where: { id: boardId },
+      include: {
+        members: true,
+        workspace: { include: { memberships: true } },
+      },
+    });
+    if (!board) {
+      throw new NotFoundException('Board not found');
+    }
+    if (board.visibility === 'PUBLIC') {
+      // allow
+    } else if (board.members.some((m) => m.userId === userId)) {
+      // allow
+    } else if (
+      board.visibility === 'WORKSPACE' &&
+      board.workspace?.memberships?.some((m) => m.userId === userId)
+    ) {
+      // allow
+    } else {
+      throw new ForbiddenException('You do not have access to this board');
+    }
+
+    const limit = Math.min(input.limit ?? 50, 50);
+    const take = limit + 1;
+    const rows = await this.prisma.activity.findMany({
+      where: { boardId },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take,
+      skip: input.cursor ? 1 : 0,
+      cursor: input.cursor ? { id: input.cursor } : undefined,
+    });
+
+    const hasMore = rows.length > limit;
+    const activities = rows.slice(0, limit).map((r) => this.toActivity(r));
+    const nextCursor =
+      hasMore && activities.length > 0 ? activities[activities.length - 1].id : null;
+
+    return {
+      activities,
+      hasMore,
+      nextCursor,
+    };
+  }
+
+  private toActivity(row: {
+    id: string;
+    type: PrismaActivityType;
+    userId: string;
+    boardId: string;
+    cardId: string | null;
+    listId: string | null;
+    payload: unknown;
+    createdAt: Date;
+  }): Activity {
+    const payload = row.payload as Record<string, unknown> | null;
+    let payloadTyped: ActivityPayload | null = null;
+    if (payload && typeof payload === 'object') {
+      payloadTyped = {
+        cardTitle: payload.cardTitle as string | undefined,
+        listName: payload.listName as string | undefined,
+        targetListName: payload.targetListName as string | undefined,
+        commentPreview: payload.commentPreview as string | undefined,
+        memberName: payload.memberName as string | undefined,
+        boardTitle: payload.boardTitle as string | undefined,
+      };
+    }
+    return {
+      id: row.id,
+      type: row.type,
+      userId: row.userId,
+      boardId: row.boardId,
+      cardId: row.cardId,
+      listId: row.listId,
+      payload: payloadTyped,
+      createdAt: row.createdAt,
+    };
+  }
+}

--- a/backend/src/modules/activity/dto/board-activity.input.ts
+++ b/backend/src/modules/activity/dto/board-activity.input.ts
@@ -1,0 +1,19 @@
+import { InputType, Field, ID, Int } from '@nestjs/graphql';
+import { IsOptional, IsInt, Min, Max } from 'class-validator';
+
+@InputType()
+export class BoardActivityInput {
+  @Field(() => Int, { nullable: true, defaultValue: 50 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  limit?: number = 50;
+
+  @Field(() => ID, {
+    nullable: true,
+    description: 'Cursor for pagination (activity id).',
+  })
+  @IsOptional()
+  cursor?: string;
+}

--- a/backend/src/modules/activity/dto/my-activity.input.ts
+++ b/backend/src/modules/activity/dto/my-activity.input.ts
@@ -1,0 +1,28 @@
+import { InputType, Field, ID, Int } from '@nestjs/graphql';
+import { IsOptional, IsInt, Min, Max, IsArray, IsUUID } from 'class-validator';
+
+@InputType()
+export class MyActivityInput {
+  @Field(() => Int, { nullable: true, defaultValue: 20 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  limit?: number = 20;
+
+  @Field(() => ID, {
+    nullable: true,
+    description: 'Cursor for pagination (activity id). Fetch activities older than this.',
+  })
+  @IsOptional()
+  cursor?: string;
+
+  @Field(() => [ID], {
+    nullable: true,
+    description: 'Filter by workspace IDs. Only activities from boards in these workspaces.',
+  })
+  @IsOptional()
+  @IsArray()
+  @IsUUID('4', { each: true })
+  workspaceIds?: string[];
+}

--- a/backend/src/modules/activity/entities/activity.entity.ts
+++ b/backend/src/modules/activity/entities/activity.entity.ts
@@ -1,0 +1,75 @@
+import { ObjectType, Field, ID, registerEnumType } from '@nestjs/graphql';
+import { ActivityType as PrismaActivityType } from '@prisma/client';
+import { User } from '../../users/entities/user.entity';
+import { Board } from '../../boards/entities/board.entity';
+
+registerEnumType(PrismaActivityType, {
+  name: 'ActivityType',
+  description: 'Type of user action recorded in the activity log',
+});
+
+@ObjectType()
+export class ActivityPayload {
+  @Field({ nullable: true })
+  cardTitle?: string;
+
+  @Field({ nullable: true })
+  listName?: string;
+
+  @Field({ nullable: true })
+  targetListName?: string;
+
+  @Field({ nullable: true })
+  commentPreview?: string;
+
+  @Field({ nullable: true })
+  memberName?: string;
+
+  @Field({ nullable: true })
+  boardTitle?: string;
+}
+
+@ObjectType()
+export class Activity {
+  @Field(() => ID)
+  id: string;
+
+  @Field(() => PrismaActivityType)
+  type: PrismaActivityType;
+
+  @Field(() => ID)
+  userId: string;
+
+  @Field(() => ID)
+  boardId: string;
+
+  @Field(() => ID, { nullable: true })
+  cardId?: string | null;
+
+  @Field(() => ID, { nullable: true })
+  listId?: string | null;
+
+  @Field(() => ActivityPayload, { nullable: true })
+  payload?: ActivityPayload | null;
+
+  @Field()
+  createdAt: Date;
+
+  @Field(() => User, { nullable: true })
+  user?: User | null;
+
+  @Field(() => Board, { nullable: true })
+  board?: Board | null;
+}
+
+@ObjectType()
+export class MyActivityResult {
+  @Field(() => [Activity])
+  activities: Activity[];
+
+  @Field()
+  hasMore: boolean;
+
+  @Field(() => ID, { nullable: true, description: 'Cursor for next page (last activity id)' })
+  nextCursor?: string | null;
+}

--- a/backend/src/modules/boards/boards.module.ts
+++ b/backend/src/modules/boards/boards.module.ts
@@ -3,9 +3,10 @@ import { BoardsService } from './boards.service';
 import { BoardsResolver } from './boards.resolver';
 import { BoardSubscriptionResolver } from './board-subscription.resolver';
 import { PrismaModule } from '../../prisma/prisma.module';
+import { ActivityModule } from '../activity/activity.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, ActivityModule],
   providers: [BoardsResolver, BoardSubscriptionResolver, BoardsService],
   exports: [BoardsService],
 })

--- a/backend/src/modules/boards/boards.resolver.spec.ts
+++ b/backend/src/modules/boards/boards.resolver.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BoardsResolver } from './boards.resolver';
 import { BoardsService } from './boards.service';
+import { ActivityService } from '../activity/activity.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { Visibility, Role } from '@prisma/client';
 
@@ -26,6 +27,12 @@ describe('BoardsResolver', () => {
     list: {
       findMany: jest.fn(),
     },
+    board: { findUnique: jest.fn() },
+    user: { findUnique: jest.fn() },
+  };
+
+  const mockActivityService = {
+    create: jest.fn().mockResolvedValue(undefined),
   };
 
   const mockUser = {
@@ -58,6 +65,10 @@ describe('BoardsResolver', () => {
         {
           provide: PrismaService,
           useValue: mockPrismaService,
+        },
+        {
+          provide: ActivityService,
+          useValue: mockActivityService,
         },
       ],
     }).compile();

--- a/backend/src/modules/boards/boards.resolver.ts
+++ b/backend/src/modules/boards/boards.resolver.ts
@@ -11,6 +11,8 @@ import { GqlAuthGuard } from '../../common/guards/gql-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { PrismaService } from '../../prisma/prisma.service';
 import { List } from '../lists/entities/list.entity';
+import { ActivityService } from '../activity/activity.service';
+import { ActivityType } from '@prisma/client';
 
 @Resolver(() => Board)
 @UseGuards(GqlAuthGuard)
@@ -18,6 +20,7 @@ export class BoardsResolver {
   constructor(
     private readonly boardsService: BoardsService,
     private readonly prisma: PrismaService,
+    private readonly activityService: ActivityService,
   ) { }
 
   @ResolveField(() => [List])
@@ -93,7 +96,14 @@ export class BoardsResolver {
     @Args('id', { type: () => ID }) id: string,
     @CurrentUser() user: any,
   ): Promise<Board> {
-    return this.boardsService.archive(id, user.id);
+    const board = await this.boardsService.archive(id, user.id);
+    await this.activityService.create({
+      type: ActivityType.BOARD_ARCHIVED,
+      userId: user.id,
+      boardId: board.id,
+      payload: { boardTitle: board.title },
+    });
+    return board;
   }
 
   @Mutation(() => Board, {
@@ -103,7 +113,14 @@ export class BoardsResolver {
     @Args('id', { type: () => ID }) id: string,
     @CurrentUser() user: any,
   ): Promise<Board> {
-    return this.boardsService.unarchive(id, user.id);
+    const board = await this.boardsService.unarchive(id, user.id);
+    await this.activityService.create({
+      type: ActivityType.BOARD_UNARCHIVED,
+      userId: user.id,
+      boardId: board.id,
+      payload: { boardTitle: board.title },
+    });
+    return board;
   }
 
   @Mutation(() => BoardMemberWithUser, {
@@ -113,7 +130,20 @@ export class BoardsResolver {
     @Args('input') input: AddBoardMemberInput,
     @CurrentUser() user: any,
   ): Promise<BoardMemberWithUser> {
-    return this.boardsService.addMember(input, user.id);
+    const result = await this.boardsService.addMember(input, user.id);
+    const [board, addedUser] = await Promise.all([
+      this.prisma.board.findUnique({ where: { id: input.boardId }, select: { title: true } }),
+      this.prisma.user.findUnique({ where: { id: input.userId }, select: { name: true } }),
+    ]);
+    if (board && addedUser) {
+      await this.activityService.create({
+        type: ActivityType.MEMBER_ADDED_TO_BOARD,
+        userId: user.id,
+        boardId: input.boardId,
+        payload: { boardTitle: board.title, memberName: addedUser.name },
+      });
+    }
+    return result;
   }
 
   @Mutation(() => Boolean, {

--- a/backend/src/modules/cards/cards.module.ts
+++ b/backend/src/modules/cards/cards.module.ts
@@ -3,9 +3,10 @@ import { CardsService } from './cards.service';
 import { CardsResolver } from './cards.resolver';
 import { CardsDataLoader } from './dataloaders/cards.dataloader';
 import { PrismaModule } from '../../prisma/prisma.module';
+import { ActivityModule } from '../activity/activity.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, ActivityModule],
   providers: [CardsService, CardsResolver, CardsDataLoader],
   exports: [CardsService, CardsDataLoader],
 })

--- a/backend/src/modules/cards/cards.resolver.spec.ts
+++ b/backend/src/modules/cards/cards.resolver.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { CardsResolver } from './cards.resolver';
 import { CardsService } from './cards.service';
 import { CardsDataLoader } from './dataloaders/cards.dataloader';
+import { ActivityService } from '../activity/activity.service';
 import { PUB_SUB } from '../../common/subscriptions/pubsub.provider';
 import { PrismaService } from '../../prisma/prisma.service';
 
@@ -15,7 +16,16 @@ describe('CardsResolver', () => {
 
   const mockPrismaService = {
     list: {
-      findUnique: jest.fn().mockResolvedValue({ boardId: 'board-1' }),
+      findUnique: jest.fn().mockResolvedValue({
+        id: 'list-1',
+        title: 'List',
+        boardId: 'board-1',
+        board: { id: 'board-1', title: 'Board' },
+      }),
+      findFirst: jest.fn(),
+    },
+    user: {
+      findUnique: jest.fn().mockResolvedValue({ id: 'user-2', name: 'Other User' }),
     },
   };
 
@@ -51,6 +61,10 @@ describe('CardsResolver', () => {
     createLabelsByCardLoader: jest.fn(() => mockLabelsLoader),
     createChecklistsByCardLoader: jest.fn(() => mockChecklistsLoader),
     createAssigneesByCardLoader: jest.fn(() => mockAssigneesLoader),
+  };
+
+  const mockActivityService = {
+    create: jest.fn().mockResolvedValue(undefined),
   };
 
   const mockUser = {
@@ -92,6 +106,10 @@ describe('CardsResolver', () => {
         {
           provide: PrismaService,
           useValue: mockPrismaService,
+        },
+        {
+          provide: ActivityService,
+          useValue: mockActivityService,
         },
       ],
     }).compile();

--- a/backend/src/modules/cards/cards.resolver.ts
+++ b/backend/src/modules/cards/cards.resolver.ts
@@ -21,6 +21,8 @@ import { Label } from '../labels/entities/label.entity';
 import DataLoader = require('dataloader');
 import { Checklist } from '../checklists/entities/checklist.entity';
 import { MemberUser } from '../invitations/entities/workspace-member.entity';
+import { ActivityService } from '../activity/activity.service';
+import { ActivityType } from '@prisma/client';
 
 @Resolver(() => Card)
 @UseGuards(GqlAuthGuard)
@@ -34,6 +36,7 @@ export class CardsResolver {
     private readonly cardsDataLoader: CardsDataLoader,
     @Inject(PUB_SUB) private readonly pubSub: PubSub,
     private readonly prisma: PrismaService,
+    private readonly activityService: ActivityService,
   ) {
     this.labelsLoader = this.cardsDataLoader.createLabelsByCardLoader();
     this.checklistsLoader = this.cardsDataLoader.createChecklistsByCardLoader();
@@ -54,6 +57,20 @@ export class CardsResolver {
   ): Promise<Card> {
     const card = await this.cardsService.create(input, user.id);
     await this.publishCardUpdated(card);
+    const list = await this.prisma.list.findUnique({
+      where: { id: card.listId },
+      include: { board: { select: { id: true, title: true } } },
+    });
+    if (list?.board) {
+      await this.activityService.create({
+        type: ActivityType.CARD_CREATED,
+        userId: user.id,
+        boardId: list.board.id,
+        cardId: card.id,
+        listId: card.listId,
+        payload: { cardTitle: card.title, listName: list.title, boardTitle: list.board.title },
+      });
+    }
     return card;
   }
 
@@ -75,8 +92,25 @@ export class CardsResolver {
     @Args('input') input: UpdateCardInput,
     @CurrentUser() user: any,
   ): Promise<Card> {
+    const previous = input.completed !== undefined ? await this.cardsService.findOne(input.id, user.id) : null;
     const card = await this.cardsService.update(input, user.id);
     await this.publishCardUpdated(card);
+    if (previous && input.completed !== undefined && previous.completed !== input.completed) {
+      const list = await this.prisma.list.findUnique({
+        where: { id: card.listId },
+        include: { board: { select: { id: true } } },
+      });
+      if (list?.board) {
+        await this.activityService.create({
+          type: input.completed ? ActivityType.CARD_COMPLETED : ActivityType.CARD_UNCOMPLETED,
+          userId: user.id,
+          boardId: list.board.id,
+          cardId: card.id,
+          listId: card.listId,
+          payload: { cardTitle: card.title, listName: list.title },
+        });
+      }
+    }
     return card;
   }
 
@@ -97,8 +131,27 @@ export class CardsResolver {
     @Args('input') input: MoveCardInput,
     @CurrentUser() user: any,
   ): Promise<Card> {
+    const cardBefore = await this.cardsService.findOne(input.cardId, user.id);
     const card = await this.cardsService.move(input, user.id);
     await this.publishCardUpdated(card);
+    const [sourceList, targetList] = await Promise.all([
+      this.prisma.list.findUnique({ where: { id: cardBefore.listId }, select: { title: true } }),
+      this.prisma.list.findUnique({ where: { id: card.listId }, include: { board: { select: { id: true } } } }),
+    ]);
+    if (targetList?.board) {
+      await this.activityService.create({
+        type: ActivityType.CARD_MOVED,
+        userId: user.id,
+        boardId: targetList.board.id,
+        cardId: card.id,
+        listId: card.listId,
+        payload: {
+          cardTitle: card.title,
+          listName: sourceList?.title ?? undefined,
+          targetListName: targetList.title,
+        },
+      });
+    }
     return card;
   }
 
@@ -123,6 +176,20 @@ export class CardsResolver {
   ): Promise<Card> {
     const card = await this.cardsService.assignMember(input, user.id);
     await this.publishCardUpdated(card);
+    const [list, assignedUser] = await Promise.all([
+      this.prisma.list.findUnique({ where: { id: card.listId }, include: { board: { select: { id: true } } } }),
+      this.prisma.user.findUnique({ where: { id: input.userId }, select: { name: true } }),
+    ]);
+    if (list?.board && assignedUser) {
+      await this.activityService.create({
+        type: ActivityType.MEMBER_ADDED_TO_CARD,
+        userId: user.id,
+        boardId: list.board.id,
+        cardId: card.id,
+        listId: card.listId,
+        payload: { cardTitle: card.title, memberName: assignedUser.name },
+      });
+    }
     return card;
   }
 
@@ -171,6 +238,19 @@ export class CardsResolver {
   ): Promise<Card> {
     const card = await this.cardsService.archive(id, user.id);
     await this.publishCardUpdated(card);
+    const list = await this.prisma.list.findUnique({
+      where: { id: card.listId },
+      select: { boardId: true },
+    });
+    if (list) {
+      await this.activityService.create({
+        type: ActivityType.CARD_ARCHIVED,
+        userId: user.id,
+        boardId: list.boardId,
+        cardId: card.id,
+        payload: { cardTitle: card.title },
+      });
+    }
     return card;
   }
 
@@ -183,6 +263,19 @@ export class CardsResolver {
   ): Promise<Card> {
     const card = await this.cardsService.unarchive(id, user.id);
     await this.publishCardUpdated(card);
+    const list = await this.prisma.list.findUnique({
+      where: { id: card.listId },
+      select: { boardId: true },
+    });
+    if (list) {
+      await this.activityService.create({
+        type: ActivityType.CARD_UNARCHIVED,
+        userId: user.id,
+        boardId: list.boardId,
+        cardId: card.id,
+        payload: { cardTitle: card.title },
+      });
+    }
     return card;
   }
 

--- a/backend/src/modules/comments/comment-subscription.resolver.spec.ts
+++ b/backend/src/modules/comments/comment-subscription.resolver.spec.ts
@@ -1,0 +1,129 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommentSubscriptionResolver } from './comment-subscription.resolver';
+import { PUB_SUB } from '../../common/subscriptions/pubsub.provider';
+import {
+  TRIGGER_COMMENT_ADDED,
+  TRIGGER_COMMENT_UPDATED,
+  TRIGGER_COMMENT_DELETED,
+  type CommentAddedPayload,
+  type CommentUpdatedPayload,
+  type CommentDeletedPayload,
+} from './comment-subscription.resolver';
+import { Comment } from './entities/comment.entity';
+
+describe('CommentSubscriptionResolver', () => {
+  let resolver: CommentSubscriptionResolver;
+  let pubSub: { asyncIterableIterator: jest.Mock };
+
+  const mockComment: Comment = {
+    id: 'comment-1',
+    cardId: 'card-1',
+    authorId: 'user-1',
+    content: 'Hello',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    const mockIterator = { [Symbol.asyncIterator]: jest.fn() };
+    pubSub = {
+      asyncIterableIterator: jest.fn().mockReturnValue(mockIterator),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CommentSubscriptionResolver,
+        {
+          provide: PUB_SUB,
+          useValue: pubSub,
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<CommentSubscriptionResolver>(CommentSubscriptionResolver);
+  });
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined();
+  });
+
+  describe('commentAdded', () => {
+    it('should return async iterable for TRIGGER_COMMENT_ADDED', () => {
+      const result = resolver.commentAdded('card-1');
+      expect(pubSub.asyncIterableIterator).toHaveBeenCalledWith(TRIGGER_COMMENT_ADDED);
+      expect(result).toBeDefined();
+      expect(typeof result[Symbol.asyncIterator]).toBe('function');
+    });
+  });
+
+  describe('commentUpdated', () => {
+    it('should return async iterable for TRIGGER_COMMENT_UPDATED', () => {
+      const result = resolver.commentUpdated('card-1');
+      expect(pubSub.asyncIterableIterator).toHaveBeenCalledWith(TRIGGER_COMMENT_UPDATED);
+      expect(result).toBeDefined();
+      expect(typeof result[Symbol.asyncIterator]).toBe('function');
+    });
+  });
+
+  describe('commentDeleted', () => {
+    it('should return async iterable for TRIGGER_COMMENT_DELETED', () => {
+      const result = resolver.commentDeleted('card-1');
+      expect(pubSub.asyncIterableIterator).toHaveBeenCalledWith(TRIGGER_COMMENT_DELETED);
+      expect(result).toBeDefined();
+      expect(typeof result[Symbol.asyncIterator]).toBe('function');
+    });
+  });
+
+  describe('subscription filter/resolve behavior', () => {
+    it('commentAdded filter should pass when cardId matches', () => {
+      const payload: CommentAddedPayload = { comment: mockComment, cardId: 'card-1' };
+      const filter = (p: CommentAddedPayload, v: { cardId: string }) =>
+        p.cardId === v.cardId;
+      expect(filter(payload, { cardId: 'card-1' })).toBe(true);
+      expect(filter(payload, { cardId: 'card-2' })).toBe(false);
+    });
+
+    it('commentUpdated filter should pass when cardId matches', () => {
+      const payload: CommentUpdatedPayload = { comment: mockComment, cardId: 'card-1' };
+      const filter = (p: CommentUpdatedPayload, v: { cardId: string }) =>
+        p.cardId === v.cardId;
+      expect(filter(payload, { cardId: 'card-1' })).toBe(true);
+      expect(filter(payload, { cardId: 'card-2' })).toBe(false);
+    });
+
+    it('commentDeleted filter should pass when cardId matches', () => {
+      const payload: CommentDeletedPayload = {
+        commentId: 'comment-1',
+        cardId: 'card-1',
+      };
+      const filter = (p: CommentDeletedPayload, v: { cardId: string }) =>
+        p.cardId === v.cardId;
+      expect(filter(payload, { cardId: 'card-1' })).toBe(true);
+      expect(filter(payload, { cardId: 'card-2' })).toBe(false);
+    });
+
+    it('commentAdded resolve should return comment from payload', () => {
+      const payload: CommentAddedPayload = { comment: mockComment, cardId: 'card-1' };
+      const resolve = (p: CommentAddedPayload) => p.comment;
+      expect(resolve(payload)).toBe(mockComment);
+    });
+
+    it('commentUpdated resolve should return comment from payload', () => {
+      const payload: CommentUpdatedPayload = { comment: mockComment, cardId: 'card-1' };
+      const resolve = (p: CommentUpdatedPayload) => p.comment;
+      expect(resolve(payload)).toBe(mockComment);
+    });
+
+    it('commentDeleted resolve should return commentId and cardId', () => {
+      const payload: CommentDeletedPayload = {
+        commentId: 'comment-1',
+        cardId: 'card-1',
+      };
+      const resolve = (p: CommentDeletedPayload) => ({
+        commentId: p.commentId,
+        cardId: p.cardId,
+      });
+      expect(resolve(payload)).toEqual({ commentId: 'comment-1', cardId: 'card-1' });
+    });
+  });
+});

--- a/backend/src/modules/comments/comments.module.ts
+++ b/backend/src/modules/comments/comments.module.ts
@@ -4,9 +4,10 @@ import { CommentsService } from './comments.service';
 import { CommentsResolver } from './comments.resolver';
 import { CommentsDataLoader } from './dataloaders/comments.dataloader';
 import { CommentSubscriptionResolver } from './comment-subscription.resolver';
+import { ActivityModule } from '../activity/activity.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, ActivityModule],
   providers: [
     CommentsService,
     CommentsResolver,

--- a/backend/src/modules/comments/comments.resolver.spec.ts
+++ b/backend/src/modules/comments/comments.resolver.spec.ts
@@ -2,7 +2,9 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { CommentsResolver } from './comments.resolver';
 import { CommentsService } from './comments.service';
 import { CommentsDataLoader } from './dataloaders/comments.dataloader';
+import { ActivityService } from '../activity/activity.service';
 import { PUB_SUB } from '../../common/subscriptions/pubsub.provider';
+import { PrismaService } from '../../prisma/prisma.service';
 
 describe('CommentsResolver', () => {
   let resolver: CommentsResolver;
@@ -26,6 +28,21 @@ describe('CommentsResolver', () => {
 
   const mockCommentsDataLoader = {
     createUsersByIdLoader: jest.fn().mockReturnValue(usersLoader),
+  };
+
+  const mockActivityService = {
+    create: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const mockPrismaService = {
+    card: {
+      findUnique: jest.fn().mockResolvedValue({
+        id: 'card-1',
+        title: 'Card',
+        listId: 'list-1',
+        list: { board: { id: 'board-1' } },
+      }),
+    },
   };
 
   const mockUser = { id: 'user-1' };
@@ -54,6 +71,14 @@ describe('CommentsResolver', () => {
         {
           provide: PUB_SUB,
           useValue: mockPubSub,
+        },
+        {
+          provide: ActivityService,
+          useValue: mockActivityService,
+        },
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
         },
       ],
     }).compile();

--- a/backend/src/modules/comments/comments.resolver.ts
+++ b/backend/src/modules/comments/comments.resolver.ts
@@ -11,6 +11,9 @@ import { GqlAuthGuard } from '../../common/guards/gql-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { PUB_SUB } from '../../common/subscriptions/pubsub.provider';
 import { PubSub } from 'graphql-subscriptions';
+import { ActivityService } from '../activity/activity.service';
+import { ActivityType } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
 import {
   TRIGGER_COMMENT_ADDED,
   TRIGGER_COMMENT_UPDATED,
@@ -26,6 +29,8 @@ export class CommentsResolver {
     private readonly commentsService: CommentsService,
     private readonly commentsDataLoader: CommentsDataLoader,
     @Inject(PUB_SUB) private readonly pubSub: PubSub,
+    private readonly activityService: ActivityService,
+    private readonly prisma: PrismaService,
   ) {
     this.usersLoader = this.commentsDataLoader.createUsersByIdLoader();
   }
@@ -64,6 +69,21 @@ export class CommentsResolver {
       comment,
       cardId: comment.cardId,
     });
+    const card = await this.prisma.card.findUnique({
+      where: { id: comment.cardId },
+      include: { list: { include: { board: { select: { id: true } } } } },
+    });
+    if (card?.list?.board) {
+      const preview = comment.content.length > 80 ? `${comment.content.slice(0, 80)}…` : comment.content;
+      await this.activityService.create({
+        type: ActivityType.COMMENT_ADDED,
+        userId: user.id,
+        boardId: card.list.board.id,
+        cardId: comment.cardId,
+        listId: card.listId,
+        payload: { cardTitle: card.title, commentPreview: preview },
+      });
+    }
     return comment;
   }
 

--- a/backend/src/modules/lists/lists.module.ts
+++ b/backend/src/modules/lists/lists.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { ListsService } from './lists.service';
 import { ListsResolver } from './lists.resolver';
 import { PrismaModule } from '../../prisma/prisma.module';
+import { ActivityModule } from '../activity/activity.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, ActivityModule],
   providers: [ListsService, ListsResolver],
   exports: [ListsService],
 })

--- a/backend/src/modules/lists/lists.resolver.spec.ts
+++ b/backend/src/modules/lists/lists.resolver.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ListsResolver } from './lists.resolver';
 import { ListsService } from './lists.service';
+import { ActivityService } from '../activity/activity.service';
 import { PUB_SUB } from '../../common/subscriptions/pubsub.provider';
 
 describe('ListsResolver', () => {
@@ -9,6 +10,10 @@ describe('ListsResolver', () => {
 
   const mockPubSub = {
     publish: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const mockActivityService = {
+    create: jest.fn().mockResolvedValue(undefined),
   };
 
   const mockListsService = {
@@ -49,6 +54,10 @@ describe('ListsResolver', () => {
         {
           provide: PUB_SUB,
           useValue: mockPubSub,
+        },
+        {
+          provide: ActivityService,
+          useValue: mockActivityService,
         },
       ],
     }).compile();

--- a/backend/src/modules/lists/lists.resolver.ts
+++ b/backend/src/modules/lists/lists.resolver.ts
@@ -10,6 +10,8 @@ import { GqlAuthGuard } from '../../common/guards/gql-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { PUB_SUB } from '../../common/subscriptions/pubsub.provider';
 import { TRIGGER_LIST_UPDATED } from '../boards/board-subscription.resolver';
+import { ActivityService } from '../activity/activity.service';
+import { ActivityType } from '@prisma/client';
 
 @Resolver(() => List)
 @UseGuards(GqlAuthGuard)
@@ -17,6 +19,7 @@ export class ListsResolver {
   constructor(
     private readonly listsService: ListsService,
     @Inject(PUB_SUB) private readonly pubSub: PubSub,
+    private readonly activityService: ActivityService,
   ) {}
 
   private async publishListUpdated(list: List): Promise<void> {
@@ -89,6 +92,13 @@ export class ListsResolver {
   ): Promise<List> {
     const list = await this.listsService.archive(id, user.id);
     await this.publishListUpdated(list);
+    await this.activityService.create({
+      type: ActivityType.LIST_ARCHIVED,
+      userId: user.id,
+      boardId: list.boardId,
+      listId: list.id,
+      payload: { listName: list.title },
+    });
     return list;
   }
 
@@ -101,6 +111,13 @@ export class ListsResolver {
   ): Promise<List> {
     const list = await this.listsService.unarchive(id, user.id);
     await this.publishListUpdated(list);
+    await this.activityService.create({
+      type: ActivityType.LIST_UNARCHIVED,
+      userId: user.id,
+      boardId: list.boardId,
+      listId: list.id,
+      payload: { listName: list.title },
+    });
     return list;
   }
 

--- a/backend/test/users.e2e-spec.ts
+++ b/backend/test/users.e2e-spec.ts
@@ -70,7 +70,7 @@ describe('Users (e2e)', () => {
         .post('/graphql')
         .send({ query: queryWithFieldError })
         .expect((res) => {
-          // GraphQL peut retourner 200 ou 400 selon l'implémentation
+          // GraphQL may return 200 or 400 depending on implementation
           expect([200, 400]).toContain(res.status);
           expect(res.body).toHaveProperty('errors');
         });

--- a/frontend/app/activity/ActivityContent.tsx
+++ b/frontend/app/activity/ActivityContent.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { useActivityInfiniteQuery } from '@/lib/queries/activity';
+import { useCurrentUserQuery } from '@/lib/queries/users';
+import type { ActivityItem } from '@/lib/actions/activity';
+import { getAvatarColor } from '@/lib/utils/avatar-colors';
+import {
+  formatRelativeTime,
+  getActivityActionText,
+  getActivityActionParts,
+} from '@/lib/activity-utils';
+import { Button } from '@/components/ui/button';
+import { LayoutGrid, Lock, X } from 'lucide-react';
+
+const linkClass =
+  'font-medium text-blue-600 underline hover:text-blue-700';
+
+function ActivityEntry({
+  item,
+  currentUserId,
+}: {
+  item: ActivityItem;
+  currentUserId?: string | null;
+}) {
+  const userName = item.user?.name ?? 'Someone';
+  const avatarColor = getAvatarColor(userName);
+  const parts = getActivityActionParts(
+    item.type,
+    userName,
+    item.payload ?? undefined
+  );
+  const actionText = getActivityActionText(
+    item.type,
+    userName,
+    item.payload ?? undefined
+  );
+  const boardTitle = item.board?.title ?? 'Board';
+  const boardId = item.boardId;
+  const cardHref =
+    boardId && item.cardId
+      ? `/boards/${boardId}?cardId=${item.cardId}`
+      : boardId
+        ? `/boards/${boardId}`
+        : null;
+  const personHref =
+    currentUserId && item.userId === currentUserId ? '/profile' : '#';
+
+  return (
+    <div className='flex gap-3 py-3 px-2 rounded-lg hover:bg-muted/50 transition-colors'>
+      <div
+        className={`shrink-0 w-8 h-8 rounded-full flex items-center justify-center text-white text-sm font-medium ${avatarColor}`}
+      >
+        {item.user?.avatar ? (
+          // eslint-disable-next-line @next/next/no-img-element -- user avatar URL, size fixed
+          <img
+            src={item.user.avatar}
+            alt=''
+            className='w-full h-full rounded-full object-cover'
+          />
+        ) : (
+          (userName.charAt(0) ?? '?').toUpperCase()
+        )}
+      </div>
+      <div className='flex-1 min-w-0'>
+        <p className='text-sm text-foreground'>
+          {parts && cardHref ? (
+            <>
+              <Link href={personHref} className={linkClass}>
+                {parts.userNameDisplay}
+              </Link>
+              {parts.afterName}
+              <Link href={cardHref} className={linkClass}>
+                {parts.cardDisplay}
+              </Link>
+              {parts.afterCard}
+            </>
+          ) : (
+            actionText
+          )}
+        </p>
+        <div className='flex items-center gap-2 mt-1 text-xs text-muted-foreground'>
+          <span>{formatRelativeTime(item.createdAt)}</span>
+          <span>·</span>
+          <Link
+            href={boardId ? `/boards/${boardId}` : '#'}
+            className='inline-flex items-center gap-1 hover:text-foreground hover:underline'
+          >
+            <LayoutGrid className='size-3.5 shrink-0' />
+            {boardTitle}
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export interface ActivityContentProps {
+  /** Filter by workspace IDs. Undefined = all workspaces. */
+  workspaceIds?: string[];
+  /** Subtitle text (e.g. "Workspaces" or workspace name). */
+  subtitle: string;
+  /** Close / back link URL. */
+  backHref: string;
+}
+
+export function ActivityContent({
+  workspaceIds,
+  subtitle,
+  backHref,
+}: ActivityContentProps) {
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    isError,
+    error,
+  } = useActivityInfiniteQuery(workspaceIds);
+
+  const activities = React.useMemo(
+    () => data?.pages.flatMap((p) => p.activities) ?? [],
+    [data]
+  );
+  const { data: currentUser } = useCurrentUserQuery();
+
+  return (
+    <div className='h-full bg-background flex flex-col p-4'>
+      <div className='p-6 w-full max-w-4xl flex flex-col flex-1 min-h-0 mx-auto'>
+        <header className='shrink-0 border-b border-accent pb-4 mb-4 flex items-center justify-between gap-4'>
+          <div className='flex flex-col gap-1 min-w-0'>
+            <h1 className='text-lg font-semibold text-foreground truncate'>
+              Activity
+            </h1>
+            <div className='flex items-center gap-2 text-sm text-muted-foreground'>
+              <Lock className='size-4 shrink-0' />
+              <span className='truncate'>{subtitle}</span>
+            </div>
+          </div>
+          <Link
+            href={backHref}
+            className='shrink-0 p-2 rounded-md hover:bg-muted text-muted-foreground hover:text-foreground'
+            aria-label='Close'
+          >
+            <X className='size-5' />
+          </Link>
+        </header>
+
+        <main className='flex-1 overflow-auto min-h-0'>
+          {isLoading && (
+            <div className='flex justify-center py-8'>
+              <div className='animate-spin h-8 w-8 border-2 border-primary border-t-transparent rounded-full' />
+            </div>
+          )}
+          {isError && (
+            <p className='text-sm text-destructive py-4'>
+              {error instanceof Error
+                ? error.message
+                : 'Failed to load activity'}
+            </p>
+          )}
+          {!isLoading && !isError && activities.length === 0 && (
+            <p className='text-sm text-muted-foreground py-8 text-center'>
+              No activity yet. Create cards, add comments, or move cards to see
+              your activity here.
+            </p>
+          )}
+          {!isLoading && !isError && activities.length > 0 && (
+            <div className='space-y-0'>
+              {activities.map((item) => (
+                <ActivityEntry
+                  key={item.id}
+                  item={item}
+                  currentUserId={currentUser?.id}
+                />
+              ))}
+            </div>
+          )}
+          {hasNextPage && !isLoading && !isError && (
+            <div className='flex justify-center pt-4 pb-2'>
+              <Button
+                variant='outline'
+                onClick={() => fetchNextPage()}
+                disabled={isFetchingNextPage}
+              >
+                {isFetchingNextPage ? (
+                  <>
+                    <span className='animate-spin mr-2 inline-block h-4 w-4 border-2 border-current border-t-transparent rounded-full' />
+                    Loading…
+                  </>
+                ) : (
+                  'Load more activity'
+                )}
+              </Button>
+            </div>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/activity/page.tsx
+++ b/frontend/app/activity/page.tsx
@@ -1,26 +1,21 @@
-export const metadata = {
-  title: "Activity",
-};
+'use client';
 
-export default async function ActivityPage() {
-  // Note: Activity tracking is not yet implemented in the backend
-  // This page will be enabled once the backend supports activity queries
+import React from 'react';
+import { useWorkspacesQuery } from '@/lib/queries/workspaces';
+import { ActivityContent } from './ActivityContent';
+
+export default function ActivityPage() {
+  const { data: workspacesData } = useWorkspacesQuery();
+  const workspaces = workspacesData ?? [];
+  const subtitle =
+    workspaces.length > 0
+      ? `Workspaces — ${workspaces.map((w) => w.name).join(', ')}`
+      : 'Workspaces';
 
   return (
-    <main className="p-6 w-full h-full overflow-auto">
-      <div className="space-y-2 mb-6">
-        <h1 className="text-2xl font-semibold">Activity</h1>
-        <p className="text-sm text-muted-foreground">Track your recent activity and changes.</p>
-      </div>
-
-      <div className="rounded-lg border border-dashed border-muted p-8 text-center bg-muted/30">
-        <div className="text-sm font-medium text-muted-foreground mb-2">
-          Activity tracking coming soon
-        </div>
-        <div className="text-xs text-muted-foreground">
-          This feature is currently being developed and will be available in a future update.
-        </div>
-      </div>
-    </main>
+    <ActivityContent
+      subtitle={subtitle}
+      backHref="/dashboard"
+    />
   );
 }

--- a/frontend/app/boards/[id]/cardEventHandlers.ts
+++ b/frontend/app/boards/[id]/cardEventHandlers.ts
@@ -3,6 +3,7 @@ import { Dispatch, SetStateAction } from 'react';
 import { createCard, moveCard, updateCard, deleteCard, archiveCard } from '@/lib/actions/cards';
 import { List, Card } from './types';
 import { boardQueryKey } from './queries';
+import { activityInvalidateKey, activityBoardInvalidateKey } from '@/lib/queries/activity';
 import { logAction, handleAsyncError } from './utils';
 
 type DetailEvent<T> = CustomEvent<T> | undefined;
@@ -15,6 +16,10 @@ export function createCardEventHandlers(
 ) {
   const invalidateBoard = () => {
     if (boardId) queryClient?.invalidateQueries({ queryKey: boardQueryKey(boardId) });
+  };
+  const invalidateActivity = () => {
+    queryClient?.invalidateQueries({ queryKey: activityInvalidateKey });
+    queryClient?.invalidateQueries({ queryKey: activityBoardInvalidateKey });
   };
   // Store full board snapshot before drag for exact rollback
   let boardSnapshot: List[] = [];
@@ -93,6 +98,7 @@ export function createCardEventHandlers(
         )
       );
       invalidateBoard();
+      invalidateActivity();
     } catch (err) {
       handleAsyncError(err, 'create card');
       setLists((prevLists) =>
@@ -156,6 +162,7 @@ export function createCardEventHandlers(
       await moveCard({ cardId, targetListId, position: targetIndex });
       logAction('✅', 'Card moved');
       invalidateBoard();
+      invalidateActivity();
     } catch (err) {
       handleAsyncError(err, 'move card');
       if (boardSnapshot.length > 0) {
@@ -319,6 +326,7 @@ export function createCardEventHandlers(
         logAction('✅', 'Card completed status updated');
       }
       invalidateBoard();
+      invalidateActivity();
     } catch (err) {
       handleAsyncError(err, 'update card completed status');
     }

--- a/frontend/app/boards/[id]/components/BoardHeader.tsx
+++ b/frontend/app/boards/[id]/components/BoardHeader.tsx
@@ -38,7 +38,9 @@ export function BoardHeader({
 
   return (
     <header
-      className={`flex items-center justify-between p-3 text-white ${board.background || 'bg-primary'} shadow-lg`}
+      className={`flex items-center justify-between p-3 text-white ${
+        board.background || 'bg-primary'
+      } shadow-lg`}
     >
       {/* Left side: Board title */}
       <div className='flex items-center gap-3'>

--- a/frontend/app/boards/[id]/components/BoardHeader/ActivityPopover.tsx
+++ b/frontend/app/boards/[id]/components/BoardHeader/ActivityPopover.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { LayoutGrid } from 'lucide-react';
+import { useBoardActivityQuery } from '@/lib/queries/activity';
+import { useCurrentUserQuery } from '@/lib/queries/users';
+import type { ActivityItem } from '@/lib/actions/activity';
+import { getAvatarColor } from '@/lib/utils/avatar-colors';
+import {
+  formatRelativeTime,
+  getActivityActionText,
+  getActivityActionParts,
+} from '@/lib/activity-utils';
+
+const linkClass =
+  'font-medium text-blue-600 underline hover:text-blue-700';
+
+function ActivityEntry({
+  item,
+  boardId,
+  currentUserId,
+}: {
+  item: ActivityItem;
+  boardId: string;
+  currentUserId?: string | null;
+}) {
+  const userName = item.user?.name ?? 'Someone';
+  const avatarColor = getAvatarColor(userName);
+  const parts = getActivityActionParts(
+    item.type,
+    userName,
+    item.payload ?? undefined
+  );
+  const actionText = getActivityActionText(
+    item.type,
+    userName,
+    item.payload ?? undefined
+  );
+  const cardHref = item.cardId
+    ? `/boards/${boardId}?cardId=${item.cardId}`
+    : `/boards/${boardId}`;
+  const personHref =
+    currentUserId && item.userId === currentUserId ? '/profile' : '#';
+
+  return (
+    <div className='flex gap-3 py-2 px-2 rounded-lg hover:bg-muted/50 transition-colors'>
+      <div
+        className={`shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-white text-xs font-medium ${avatarColor}`}
+      >
+        {item.user?.avatar ? (
+          // eslint-disable-next-line @next/next/no-img-element -- user avatar URL
+          <img
+            src={item.user.avatar}
+            alt=''
+            className='w-full h-full rounded-full object-cover'
+          />
+        ) : (
+          (userName.charAt(0) ?? '?').toUpperCase()
+        )}
+      </div>
+      <div className='flex-1 min-w-0'>
+        <p className='text-sm text-foreground leading-tight'>
+          {parts ? (
+            <>
+              <Link href={personHref} className={linkClass}>
+                {parts.userNameDisplay}
+              </Link>
+              {parts.afterName}
+              <Link href={cardHref} className={linkClass}>
+                {parts.cardDisplay}
+              </Link>
+              {parts.afterCard}
+            </>
+          ) : (
+            actionText
+          )}
+        </p>
+        <span className='text-xs text-muted-foreground'>
+          {formatRelativeTime(item.createdAt)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export interface BoardActivityListProps {
+  boardId: string;
+  boardTitle: string;
+  /** When true, the query runs (e.g. when submenu is open). */
+  enabled?: boolean;
+}
+
+/**
+ * Activity list for the current board. Used inside the board menu submenu.
+ */
+export function BoardActivityList({
+  boardId,
+  boardTitle,
+  enabled = true,
+}: BoardActivityListProps) {
+  const { data, isLoading, isError, error } = useBoardActivityQuery(
+    boardId,
+    enabled
+  );
+  const { data: currentUser } = useCurrentUserQuery();
+  const activities = data?.activities ?? [];
+
+  return (
+    <>
+      <div className='border-b border-accent px-3 py-2.5 flex items-center justify-between gap-2'>
+        <div className='flex items-center gap-2'>
+          <LayoutGrid className='w-4 h-4 text-muted-foreground shrink-0' />
+          <h3 className='font-semibold text-sm text-foreground truncate'>
+            Activity — {boardTitle}
+          </h3>
+        </div>
+        <Link
+          href='/activity'
+          className='text-xs text-primary hover:underline shrink-0'
+        >
+          View all
+        </Link>
+      </div>
+      <div className='max-h-[320px] overflow-y-auto'>
+        {isLoading && (
+          <div className='flex justify-center py-8'>
+            <div className='animate-spin h-6 w-6 border-2 border-primary border-t-transparent rounded-full' />
+          </div>
+        )}
+        {isError && (
+          <p className='text-sm text-destructive px-3 py-4'>
+            {error instanceof Error ? error.message : 'Failed to load activity'}
+          </p>
+        )}
+        {!isLoading && !isError && activities.length === 0 && (
+          <p className='text-sm text-muted-foreground px-3 py-6 text-center'>
+            No activity on this board yet.
+          </p>
+        )}
+        {!isLoading && !isError && activities.length > 0 && (
+          <div className='space-y-0 px-2 py-1'>
+            {activities.slice(0, 25).map((item) => (
+              <ActivityEntry
+                key={item.id}
+                item={item}
+                boardId={boardId}
+                currentUserId={currentUser?.id}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/frontend/app/boards/[id]/components/BoardHeader/BoardMenu.tsx
+++ b/frontend/app/boards/[id]/components/BoardHeader/BoardMenu.tsx
@@ -50,6 +50,7 @@ import {
   ItemDescription,
 } from '@/components/ui/item';
 import { ArchivedItemsContent } from './ArchivedItemsDialog';
+import { BoardActivityList } from './ActivityPopover';
 import { BoardMenuDialogs } from './BoardMenuDialogs';
 import type { BoardMember } from '../../types';
 import type { Board } from '../../types';
@@ -207,9 +208,6 @@ export function BoardMenu({
     toast.info('Stickers feature coming soon');
   };
 
-  const handleActivity = () => {
-    toast.info('Activity feature coming soon');
-  };
 
   const handlePrintExportShare = () => {
     // Print functionality
@@ -416,13 +414,18 @@ export function BoardMenu({
                   <Sticker className='w-4 h-4' />
                   <span>Stickers</span>
                 </DropdownMenuItem>
-                <DropdownMenuItem
-                  className='flex items-center gap-2'
-                  onClick={handleActivity}
-                >
-                  <Activity className='w-4 h-4' />
-                  <span>Activity</span>
-                </DropdownMenuItem>
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger className='flex items-center gap-2'>
+                    <Activity className='w-4 h-4' />
+                    <span>Activity</span>
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent className='w-[380px] p-0 border-accent'>
+                    <BoardActivityList
+                      boardId={board.id}
+                      boardTitle={board.title}
+                    />
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
                 <DropdownMenuSub>
                   <DropdownMenuSubTrigger className='flex items-center gap-2'>
                     <Archive className='w-4 h-4' />

--- a/frontend/app/boards/[id]/components/BoardHeader/ShareDialog.tsx
+++ b/frontend/app/boards/[id]/components/BoardHeader/ShareDialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { Share2, Copy, Check } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -24,6 +25,7 @@ import { Separator } from '@/components/ui/separator';
 import { getAvatarColor } from '@/lib/utils/avatar-colors';
 import { getUserByEmail } from '@/lib/actions/users';
 import { addBoardMember } from '@/lib/actions/boards';
+import { activityInvalidateKey, activityBoardInvalidateKey } from '@/lib/queries/activity';
 import { toast } from '@/lib/toast';
 import type { BoardMember } from '../../types';
 
@@ -42,6 +44,7 @@ export function ShareDialog({
   members,
   onMemberAdded,
 }: ShareDialogProps) {
+  const queryClient = useQueryClient();
   const [inviteEmail, setInviteEmail] = useState('');
   const [inviteRole, setInviteRole] = useState<'MEMBER' | 'ADMIN'>('MEMBER');
   const [inviteLoading, setInviteLoading] = useState(false);
@@ -52,7 +55,7 @@ export function ShareDialog({
       typeof window !== 'undefined'
         ? `${window.location.origin}/boards/${boardId}`
         : '',
-    [boardId],
+    [boardId]
   );
 
   const handleCopyLink = async () => {
@@ -86,6 +89,8 @@ export function ShareDialog({
         return;
       }
       await addBoardMember(boardId, user.id, inviteRole);
+      await queryClient.invalidateQueries({ queryKey: activityInvalidateKey });
+      await queryClient.invalidateQueries({ queryKey: activityBoardInvalidateKey });
       toast.success(`${user.name || user.email} has been added to the board`);
       setInviteEmail('');
       onMemberAdded?.();

--- a/frontend/app/boards/[id]/listEventHandlers.ts
+++ b/frontend/app/boards/[id]/listEventHandlers.ts
@@ -4,6 +4,7 @@ import { createList, updateList, reorderLists, deleteList, archiveList } from '@
 import { createCard, moveCard } from '@/lib/actions/cards';
 import { List, Card } from './types';
 import { boardQueryKey } from './queries';
+import { activityInvalidateKey, activityBoardInvalidateKey } from '@/lib/queries/activity';
 import { logAction, handleAsyncError } from './utils';
 
 type DetailEvent<T> = CustomEvent<T> | undefined;
@@ -15,6 +16,10 @@ export function createListEventHandlers(
 ) {
   const invalidateBoard = () => {
     queryClient?.invalidateQueries({ queryKey: boardQueryKey(boardId) });
+  };
+  const invalidateActivity = () => {
+    queryClient?.invalidateQueries({ queryKey: activityInvalidateKey });
+    queryClient?.invalidateQueries({ queryKey: activityBoardInvalidateKey });
   };
   async function handleListCreate(e?: DetailEvent<{ title: string }>) {
     const detail = e?.detail;
@@ -194,6 +199,7 @@ export function createListEventHandlers(
         }
         logAction('✅', 'All cards moved');
         invalidateBoard();
+        invalidateActivity();
       } catch (err) {
         handleAsyncError(err, 'move all cards');
       }

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -1,116 +1,110 @@
-"use client";
+'use client';
 
-import React, { useEffect, useState } from "react";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Separator } from "@/components/ui/separator";
-import { Skeleton } from "@/components/ui/skeleton";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { getCurrentUser, type User } from "@/lib/actions/users";
+import React from 'react';
+import Link from 'next/link';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useCurrentUserQuery } from '@/lib/queries/users';
+import { getAvatarColor } from '@/lib/utils/avatar-colors';
+import { getInitials } from '@/lib/utils';
+import { Settings } from 'lucide-react';
 
 export default function ProfilePage() {
-  const [user, setUser] = useState<User | null>(null);
-  const [loading, setLoading] = useState(true);
+  const { data: user, isLoading: loading } = useCurrentUserQuery();
 
-  useEffect(() => {
-    const load = async () => {
-      setLoading(true);
-      try {
-        const me = await getCurrentUser();
-        setUser(me);
-      } catch (error) {
-        console.error("Failed to load profile", error);
-        setUser(null);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    load();
-  }, []);
-
-  const getInitials = (name?: string) => {
-    if (!name) return "U";
-    return name
-      .split(" ")
-      .filter(Boolean)
-      .map((part) => part[0])
-      .join("")
-      .slice(0, 2)
-      .toUpperCase();
-  };
-
-  const content = loading ? (
-    <div className="space-y-6">
-      <div className="flex items-center gap-4">
-        <Skeleton className="h-16 w-16 rounded-full" />
-        <div className="space-y-2 w-full max-w-sm">
-          <Skeleton className="h-5 w-48" />
-          <Skeleton className="h-4 w-64" />
+  if (loading) {
+    return (
+      <div className="h-full w-full flex flex-col p-4">
+        <div className="p-6 w-full max-w-4xl space-y-6 mx-auto flex-1">
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-64" />
+            <Skeleton className="h-4 w-96" />
+          </div>
+          <Separator />
+          <div className="flex items-center gap-4">
+            <Skeleton className="h-16 w-16 rounded-full" />
+            <div className="space-y-2">
+              <Skeleton className="h-5 w-48" />
+              <Skeleton className="h-4 w-64" />
+            </div>
+          </div>
+          <Separator />
+          <div className="grid gap-4 max-w-xl">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-16" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          </div>
         </div>
       </div>
-      <Separator />
-      <div className="grid gap-4 max-w-xl">
-        <div className="space-y-2">
-          <Skeleton className="h-4 w-20" />
-          <Skeleton className="h-10 w-full" />
-        </div>
-        <div className="space-y-2">
-          <Skeleton className="h-4 w-16" />
-          <Skeleton className="h-10 w-full" />
-        </div>
-      </div>
-    </div>
-  ) : (
-    <div className="space-y-6">
-      <div className="flex items-center gap-4">
-        <Avatar className="h-16 w-16">
-          <AvatarImage src={user?.avatar} alt={user?.name || "User avatar"} />
-          <AvatarFallback>{getInitials(user?.name)}</AvatarFallback>
-        </Avatar>
-        <div className="space-y-1">
-          <p className="text-lg font-semibold">{user?.name || "Unknown user"}</p>
-          <p className="text-sm text-muted-foreground">{user?.email || "No email available"}</p>
-        </div>
-      </div>
-
-      <Separator />
-
-      <div className="grid gap-4 max-w-xl">
-        <div className="space-y-2">
-          <Label htmlFor="profile-name">Full name</Label>
-          <Input
-            id="profile-name"
-            value={user?.name || ""}
-            readOnly
-            aria-readonly
-            disabled
-          />
-        </div>
-
-        <div className="space-y-2">
-          <Label htmlFor="profile-email">Email</Label>
-          <Input
-            id="profile-email"
-            type="email"
-            value={user?.email || ""}
-            readOnly
-            aria-readonly
-            disabled
-          />
-        </div>
-      </div>
-    </div>
-  );
+    );
+  }
 
   return (
-    <main className="p-6 w-full h-full overflow-auto">
-      <div className="space-y-2 mb-6">
-        <h1 className="text-2xl font-semibold">Profile and visibility</h1>
-        <p className="text-sm text-muted-foreground">View your account details. Fields are read-only.</p>
-      </div>
+    <div className="h-full w-full flex flex-col p-4">
+      <div className="p-6 w-full max-w-4xl space-y-6 mx-auto">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div className="space-y-1">
+            <h1 className="text-2xl font-semibold">Profile and visibility</h1>
+            <p className="text-sm text-muted-foreground">
+              View your account details. To edit your name or email, go to
+              Settings.
+            </p>
+          </div>
+          <Button variant="outline" asChild>
+            <Link href="/settings" className="inline-flex items-center gap-2">
+              <Settings className="h-4 w-4" />
+              Edit in Settings
+            </Link>
+          </Button>
+        </div>
 
-      {content}
-    </main>
+        <Separator />
+
+        <div className="flex items-center gap-4">
+          <Avatar className="h-16 w-16">
+            <AvatarImage src={user?.avatar} alt={user?.name ?? 'User avatar'} />
+            <AvatarFallback
+              className={`text-white text-lg ${getAvatarColor(
+                user?.name ?? user?.email
+              )}`}
+            >
+              {getInitials(user?.name, user?.email)}
+            </AvatarFallback>
+          </Avatar>
+          <div className="space-y-1">
+            <p className="text-lg font-semibold">
+              {user?.name ?? 'Unknown user'}
+            </p>
+            <p className="text-sm text-muted-foreground">
+              {user?.email ?? 'No email'}
+            </p>
+          </div>
+        </div>
+
+        <Separator />
+
+        <div className="grid gap-4 max-w-xl">
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-muted-foreground">
+              Full name
+            </label>
+            <p className="text-sm font-medium">{user?.name ?? '—'}</p>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-muted-foreground">
+              Email
+            </label>
+            <p className="text-sm font-medium">{user?.email ?? '—'}</p>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/frontend/app/workspaces/[id]/activity/page.tsx
+++ b/frontend/app/workspaces/[id]/activity/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import React from 'react';
+import { useParams } from 'next/navigation';
+import { useWorkspaceQuery } from '@/lib/queries/workspaces';
+import { ActivityContent } from '@/app/activity/ActivityContent';
+
+export default function WorkspaceActivityPage() {
+  const params = useParams();
+  const workspaceId = typeof params.id === 'string' ? params.id : undefined;
+  const { data: workspace } = useWorkspaceQuery(workspaceId ?? '');
+
+  const subtitle = workspace?.name ?? 'Workspace';
+  const backHref = workspaceId ? `/workspaces/${workspaceId}/boards` : '/dashboard';
+
+  return (
+    <ActivityContent
+      workspaceIds={workspaceId ? [workspaceId] : undefined}
+      subtitle={subtitle}
+      backHref={backHref}
+    />
+  );
+}

--- a/frontend/components/CardModal.tsx
+++ b/frontend/components/CardModal.tsx
@@ -85,6 +85,7 @@ import {
   deleteChecklistItem as deleteChecklistItemAPI,
 } from '@/lib/actions/checklists';
 import { boardQueryKey, useBoardQuery } from '@/app/boards/[id]/queries';
+import { activityInvalidateKey, activityBoardInvalidateKey } from '@/lib/queries/activity';
 import { useWorkspaceQuery } from '@/lib/queries/workspaces';
 import { useCurrentUserQuery } from '@/lib/queries/users';
 import { toast } from '@/lib/toast';
@@ -913,6 +914,8 @@ export default function CardModal({
         cardCommentsQueryKey(card.id),
         (prev) => (prev ? [...prev, created] : [created])
       );
+      await queryClient.invalidateQueries({ queryKey: activityInvalidateKey });
+      await queryClient.invalidateQueries({ queryKey: activityBoardInvalidateKey });
       setNewComment('');
       emitEvent('epitrello:card-comments-updated', {
         cardId: card.id,
@@ -984,9 +987,9 @@ export default function CardModal({
     card.listId || ''
   );
   const [selectedPosition, setSelectedPosition] = useState<string>('1');
-  // Menu de déplacement dans le header
+  // Move menu in the header
   const [isHeaderMoveOpen, setIsHeaderMoveOpen] = useState(false);
-  // Popover de déplacement utilisé dans la section Dates (overdue)
+  // Move popover used in the Dates section (overdue)
   const [isMovePopoverOpen, setIsMovePopoverOpen] = useState(false);
 
   const handleMoveCard = () => {

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -20,6 +20,7 @@ import {
   Mail,
   Building2,
   CreditCard,
+  ListTodo,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -183,6 +184,10 @@ export default function AppSidebar() {
     router.push(`/workspaces/${wid}/settings`);
   };
 
+  const onActivity = (wid: string) => {
+    router.push(`/workspaces/${wid}/activity`);
+  };
+
   if (isAuthPage) {
     return null;
   }
@@ -256,6 +261,16 @@ export default function AppSidebar() {
                   >
                     <CreditCard />
                     <span>Cards</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    onClick={() => router.push('/activity')}
+                    isActive={pathname === '/activity'}
+                    tooltip='Activity'
+                  >
+                    <ListTodo />
+                    <span>Activity</span>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               </SidebarMenu>
@@ -336,6 +351,9 @@ export default function AppSidebar() {
               const settingsActive =
                 !!pathname &&
                 pathname.startsWith(`/workspaces/${w.id}/settings`);
+              const activityActive =
+                !!pathname &&
+                pathname.startsWith(`/workspaces/${w.id}/activity`);
 
               return (
                 <Collapsible
@@ -388,6 +406,16 @@ export default function AppSidebar() {
                             >
                               <Settings />
                               <span>Settings</span>
+                            </SidebarMenuButton>
+                          </SidebarMenuItem>
+                          <SidebarMenuItem>
+                            <SidebarMenuButton
+                              onClick={() => onActivity(w.id)}
+                              isActive={activityActive}
+                              tooltip='Activity'
+                            >
+                              <ListTodo />
+                              <span>Activity</span>
                             </SidebarMenuButton>
                           </SidebarMenuItem>
                         </SidebarMenu>

--- a/frontend/components/Topbar.tsx
+++ b/frontend/components/Topbar.tsx
@@ -387,47 +387,33 @@ export default function Topbar() {
                 </a>
               </DropdownMenuItem>
               <DropdownMenuItem asChild>
-                <a href='/settings' className='cursor-pointer'>
+                <Link href='/settings' className='cursor-pointer'>
                   Manage account
-                </a>
+                </Link>
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuLabel className='text-xs text-muted-foreground font-medium px-2 py-1.5'>
                 Trello
               </DropdownMenuLabel>
               <DropdownMenuItem asChild>
-                <a href='/auth/me' className='cursor-pointer'>
+                <Link href='/profile' className='cursor-pointer'>
                   Profile and visibility
-                </a>
+                </Link>
               </DropdownMenuItem>
               <DropdownMenuItem asChild>
-                <a
-                  href='#'
-                  onClick={(e) => {
-                    e.preventDefault();
-                    alert('Activity (not implemented)');
-                  }}
-                  className='cursor-pointer'
-                >
+                <Link href='/activity' className='cursor-pointer'>
                   Activity
-                </a>
+                </Link>
               </DropdownMenuItem>
               <DropdownMenuItem asChild>
-                <a
-                  href='#'
-                  onClick={(e) => {
-                    e.preventDefault();
-                    alert('Cards (not implemented)');
-                  }}
-                  className='cursor-pointer'
-                >
+                <Link href='/cards' className='cursor-pointer'>
                   Cards
-                </a>
+                </Link>
               </DropdownMenuItem>
               <DropdownMenuItem asChild>
-                <a href='/settings' className='cursor-pointer'>
+                <Link href='/settings' className='cursor-pointer'>
                   Settings
-                </a>
+                </Link>
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem asChild>

--- a/frontend/lib/actions/activity.ts
+++ b/frontend/lib/actions/activity.ts
@@ -1,0 +1,160 @@
+import { graphqlRequest } from '../graphql-client';
+
+export type ActivityType =
+  | 'CARD_CREATED'
+  | 'CARD_COMPLETED'
+  | 'CARD_UNCOMPLETED'
+  | 'CARD_MOVED'
+  | 'COMMENT_ADDED'
+  | 'MEMBER_ADDED_TO_CARD'
+  | 'MEMBER_ADDED_TO_BOARD'
+  | 'CARD_ARCHIVED'
+  | 'CARD_UNARCHIVED'
+  | 'LIST_ARCHIVED'
+  | 'LIST_UNARCHIVED'
+  | 'BOARD_ARCHIVED'
+  | 'BOARD_UNARCHIVED';
+
+export interface ActivityPayload {
+  cardTitle?: string;
+  listName?: string;
+  targetListName?: string;
+  commentPreview?: string;
+  memberName?: string;
+  boardTitle?: string;
+}
+
+export interface ActivityUser {
+  id: string;
+  name: string;
+  avatar?: string | null;
+}
+
+export interface ActivityBoard {
+  id: string;
+  title: string;
+}
+
+export interface ActivityItem {
+  id: string;
+  type: ActivityType;
+  userId: string;
+  boardId: string;
+  cardId?: string | null;
+  listId?: string | null;
+  payload?: ActivityPayload | null;
+  createdAt: string;
+  user?: ActivityUser | null;
+  board?: ActivityBoard | null;
+}
+
+export interface MyActivityResult {
+  activities: ActivityItem[];
+  hasMore: boolean;
+  nextCursor?: string | null;
+}
+
+export interface MyActivityInput {
+  limit?: number;
+  cursor?: string;
+  workspaceIds?: string[];
+}
+
+export interface BoardActivityInput {
+  limit?: number;
+  cursor?: string;
+}
+
+/**
+ * Get activity for a board (all members). User must have access to the board.
+ */
+export async function getBoardActivity(
+  boardId: string,
+  input?: BoardActivityInput,
+): Promise<MyActivityResult> {
+  const query = `
+    query BoardActivity($boardId: String!, $input: BoardActivityInput) {
+      boardActivity(boardId: $boardId, input: $input) {
+        activities {
+          id
+          type
+          userId
+          boardId
+          cardId
+          listId
+          payload {
+            cardTitle
+            listName
+            targetListName
+            commentPreview
+            memberName
+            boardTitle
+          }
+          createdAt
+          user {
+            id
+            name
+            avatar
+          }
+          board {
+            id
+            title
+          }
+        }
+        hasMore
+        nextCursor
+      }
+    }
+  `;
+
+  const result = await graphqlRequest<{ boardActivity: MyActivityResult }>(query, {
+    boardId,
+    input: input ?? undefined,
+  });
+  return result.boardActivity;
+}
+
+/**
+ * Get current user's activity log with optional workspace filter and pagination.
+ */
+export async function getMyActivity(input?: MyActivityInput): Promise<MyActivityResult> {
+  const query = `
+    query MyActivity($input: MyActivityInput) {
+      myActivity(input: $input) {
+        activities {
+          id
+          type
+          userId
+          boardId
+          cardId
+          listId
+          payload {
+            cardTitle
+            listName
+            targetListName
+            commentPreview
+            memberName
+            boardTitle
+          }
+          createdAt
+          user {
+            id
+            name
+            avatar
+          }
+          board {
+            id
+            title
+          }
+        }
+        hasMore
+        nextCursor
+      }
+    }
+  `;
+
+  const result = await graphqlRequest<{ myActivity: MyActivityResult }>(query, {
+    input: input ?? undefined,
+  });
+  return result.myActivity;
+}

--- a/frontend/lib/activity-utils.ts
+++ b/frontend/lib/activity-utils.ts
@@ -1,0 +1,166 @@
+import type { ActivityItem, ActivityType } from '@/lib/actions/activity';
+
+export function formatRelativeTime(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+
+  if (diffSec < 60) return 'Just now';
+  if (diffMin < 60) return `${diffMin} minute${diffMin !== 1 ? 's' : ''} ago`;
+  if (diffHour < 24) return `${diffHour} hour${diffHour !== 1 ? 's' : ''} ago`;
+  if (diffDay < 7) return `${diffDay} day${diffDay !== 1 ? 's' : ''} ago`;
+  return date.toLocaleDateString();
+}
+
+export function getActivityActionText(
+  type: ActivityType,
+  userName: string,
+  payload: ActivityItem['payload']
+): string {
+  const name = userName || 'Someone';
+  const card = payload?.cardTitle ? `"${payload.cardTitle}"` : 'a card';
+  const list = payload?.listName ?? '';
+  const targetList = payload?.targetListName ?? '';
+  const board = payload?.boardTitle ?? 'a board';
+  const member = payload?.memberName ?? '';
+  const preview = payload?.commentPreview
+    ? `: "${payload.commentPreview}"`
+    : '';
+
+  switch (type) {
+    case 'CARD_CREATED':
+      return `${name} created ${card} in ${list}`;
+    case 'CARD_COMPLETED':
+      return `${name} marked ${card} complete`;
+    case 'CARD_UNCOMPLETED':
+      return `${name} marked ${card} incomplete`;
+    case 'CARD_MOVED':
+      return targetList
+        ? `${name} moved ${card} to ${targetList}`
+        : `${name} moved ${card}`;
+    case 'COMMENT_ADDED':
+      return `${name} commented on ${card}${preview}`;
+    case 'MEMBER_ADDED_TO_CARD':
+      return member
+        ? `${name} added ${member} to ${card}`
+        : `${name} added a member to ${card}`;
+    case 'MEMBER_ADDED_TO_BOARD':
+      return member
+        ? `${name} added ${member} to board ${board}`
+        : `${name} added a member to ${board}`;
+    case 'CARD_ARCHIVED':
+      return `${name} archived ${card}`;
+    case 'CARD_UNARCHIVED':
+      return `${name} unarchived ${card}`;
+    case 'LIST_ARCHIVED':
+      return `${name} archived the list "${list || 'Untitled'}"`;
+    case 'LIST_UNARCHIVED':
+      return `${name} unarchived the list "${list || 'Untitled'}"`;
+    case 'BOARD_ARCHIVED':
+      return `${name} archived the board ${board}`;
+    case 'BOARD_UNARCHIVED':
+      return `${name} unarchived the board ${board}`;
+    default:
+      return `${name} performed an action`;
+  }
+}
+
+/** Parts to render action text with user name and card name as separate linkable segments. */
+export function getActivityActionParts(
+  type: ActivityType,
+  userName: string,
+  payload: ActivityItem['payload']
+): {
+  userNameDisplay: string;
+  afterName: string;
+  cardDisplay: string;
+  afterCard: string;
+} | null {
+  const name = userName || 'Someone';
+  const cardDisplay = payload?.cardTitle ? `"${payload.cardTitle}"` : 'a card';
+  const list = payload?.listName ?? '';
+  const targetList = payload?.targetListName ?? '';
+  const member = payload?.memberName ?? '';
+  const preview = payload?.commentPreview
+    ? `: "${payload.commentPreview}"`
+    : '';
+
+  switch (type) {
+    case 'CARD_CREATED':
+      return {
+        userNameDisplay: name,
+        afterName: ' created ',
+        cardDisplay,
+        afterCard: ` in ${list}`,
+      };
+    case 'CARD_COMPLETED':
+      return {
+        userNameDisplay: name,
+        afterName: ' marked ',
+        cardDisplay,
+        afterCard: ' complete',
+      };
+    case 'CARD_UNCOMPLETED':
+      return {
+        userNameDisplay: name,
+        afterName: ' marked ',
+        cardDisplay,
+        afterCard: ' incomplete',
+      };
+    case 'CARD_MOVED':
+      return targetList
+        ? {
+            userNameDisplay: name,
+            afterName: ' moved ',
+            cardDisplay,
+            afterCard: ` to ${targetList}`,
+          }
+        : {
+            userNameDisplay: name,
+            afterName: ' moved ',
+            cardDisplay,
+            afterCard: '',
+          };
+    case 'COMMENT_ADDED':
+      return {
+        userNameDisplay: name,
+        afterName: ' commented on ',
+        cardDisplay,
+        afterCard: preview,
+      };
+    case 'MEMBER_ADDED_TO_CARD':
+      return member
+        ? {
+            userNameDisplay: name,
+            afterName: ` added ${member} to `,
+            cardDisplay,
+            afterCard: '',
+          }
+        : {
+            userNameDisplay: name,
+            afterName: ' added a member to ',
+            cardDisplay,
+            afterCard: '',
+          };
+    case 'CARD_ARCHIVED':
+      return {
+        userNameDisplay: name,
+        afterName: ' archived ',
+        cardDisplay,
+        afterCard: '',
+      };
+    case 'CARD_UNARCHIVED':
+      return {
+        userNameDisplay: name,
+        afterName: ' unarchived ',
+        cardDisplay,
+        afterCard: '',
+      };
+    default:
+      return null;
+  }
+}

--- a/frontend/lib/queries/activity.ts
+++ b/frontend/lib/queries/activity.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import {
+  getMyActivity,
+  getBoardActivity,
+  type MyActivityInput,
+} from '@/lib/actions/activity';
+
+export const activityQueryKey = (input?: MyActivityInput) =>
+  ['activity', input?.workspaceIds ?? null, input?.cursor ?? 'initial'] as const;
+
+export function useMyActivityQuery(input?: MyActivityInput) {
+  return useQuery({
+    queryKey: activityQueryKey(input),
+    queryFn: () => getMyActivity(input),
+    staleTime: 30 * 1000,
+  });
+}
+
+export const activityInfiniteQueryKey = (workspaceIds?: string[]) =>
+  ['activityInfinite', workspaceIds ?? null] as const;
+
+/** Invalidate to refetch the Activity page. */
+export const activityInvalidateKey = ['activityInfinite'] as const;
+
+/** Invalidate to refetch board header activity popover(s). */
+export const activityBoardInvalidateKey = ['activity'] as const;
+
+/**
+ * Infinite query for Activity page: first page, then "Load more" via fetchNextPage.
+ */
+export function useActivityInfiniteQuery(workspaceIds?: string[]) {
+  return useInfiniteQuery({
+    queryKey: activityInfiniteQueryKey(workspaceIds),
+    queryFn: ({ pageParam }) =>
+      getMyActivity({ limit: 20, cursor: pageParam as string | undefined, workspaceIds }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.nextCursor ?? undefined : undefined),
+    staleTime: 30 * 1000,
+  });
+}
+
+export const boardActivityQueryKey = (boardId: string) =>
+  ['activity', 'board', boardId] as const;
+
+/**
+ * Activity for a single board (all members). Used in board header popover.
+ */
+export function useBoardActivityQuery(boardId: string, enabled: boolean) {
+  return useQuery({
+    queryKey: boardActivityQueryKey(boardId),
+    queryFn: () => getBoardActivity(boardId, { limit: 50 }),
+    enabled: !!boardId && enabled,
+    staleTime: 30 * 1000,
+  });
+}


### PR DESCRIPTION
…nts, profile/topbar links

- Add boardActivity query (all members on board) and findBoardActivity in ActivityService
- Record CARD_ARCHIVED, CARD_UNARCHIVED, LIST_ARCHIVED, LIST_UNARCHIVED, BOARD_ARCHIVED, BOARD_UNARCHIVED in resolvers
- Frontend: getBoardActivity, useBoardActivityQuery calls boardActivity; activity types and labels for archive events
- Topbar: Activity/Cards/Manage account/Profile and visibility/Settings link to correct pages
- Profile page: useCurrentUserQuery, getInitials/getAvatarColor from utils, padding aligned with other pages
- Activity entries: person and card names as blue underlined links; comment and filter coverage in http-exception filter