### PR TITLE
test: improve coverage for notifications, filter, and guard

### DIFF
--- a/backend/src/common/filters/http-exception.filter.spec.ts
+++ b/backend/src/common/filters/http-exception.filter.spec.ts
@@ -1,10 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AllExceptionsFilter } from './http-exception.filter';
-import { HttpException, HttpStatus } from '@nestjs/common';
+import { HttpException, HttpStatus, Logger } from '@nestjs/common';
 import { GraphQLError } from 'graphql';
 
 describe('AllExceptionsFilter', () => {
   let filter: AllExceptionsFilter;
+  const envNodeEnv = process.env.NODE_ENV;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -12,6 +13,10 @@ describe('AllExceptionsFilter', () => {
     }).compile();
 
     filter = module.get<AllExceptionsFilter>(AllExceptionsFilter);
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = envNodeEnv;
   });
 
   it('should be defined', () => {
@@ -38,6 +43,10 @@ describe('AllExceptionsFilter', () => {
 
     expect(result).toBeInstanceOf(GraphQLError);
     expect((result as GraphQLError).message).toBe('Validation failed');
+    expect((result as GraphQLError).extensions?.response).toEqual({
+      message: 'Validation failed',
+      error: 'Bad Request',
+    });
   });
 
   it('should handle HTTP exception with array message in response', () => {
@@ -96,5 +105,34 @@ describe('AllExceptionsFilter', () => {
     expect((result as GraphQLError).extensions?.code).toBe(
       HttpStatus.INTERNAL_SERVER_ERROR,
     );
+  });
+
+  it('should log unhandled exception in development', () => {
+    process.env.NODE_ENV = 'development';
+    const exception = new Error('Some internal error');
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+    const result = filter.catch(exception);
+
+    expect(result).toBeInstanceOf(GraphQLError);
+    expect((result as GraphQLError).message).toBe('Internal server error');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unhandled exception [Error]'),
+      expect.any(String),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('should not log stack when exception is not Error in development', () => {
+    process.env.NODE_ENV = 'development';
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+    filter.catch('string error');
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unhandled exception [string]'),
+      '',
+    );
+    warnSpy.mockRestore();
   });
 });

--- a/backend/src/common/guards/gql-auth.guard.spec.ts
+++ b/backend/src/common/guards/gql-auth.guard.spec.ts
@@ -169,5 +169,77 @@ describe('GqlAuthGuard', () => {
       expect(result).toEqual(mockRequest);
       expect(Logger.prototype.debug).toHaveBeenCalledWith('No authorization header found');
     });
+
+    it('should use user from connection context when req has no user (WebSocket)', () => {
+      const mockUser = { id: 'user-1', email: 'ws@test.com' };
+      const mockContext = {
+        req: undefined,
+        user: mockUser,
+      };
+
+      const mockExecutionContext = {
+        switchToHttp: jest.fn(),
+        getType: jest.fn().mockReturnValue('graphql'),
+      } as unknown as ExecutionContext;
+
+      jest.spyOn(GqlExecutionContext, 'create').mockReturnValue({
+        getContext: jest.fn().mockReturnValue(mockContext),
+      } as any);
+
+      const result = guard.getRequest(mockExecutionContext);
+
+      expect(result).toEqual({ user: mockUser });
+      expect(Logger.prototype.debug).toHaveBeenCalledWith(
+        'Subscription or pre-authenticated context (user from connection)',
+      );
+    });
+  });
+
+  describe('canActivate (WebSocket / subscription)', () => {
+    it('should throw UnauthorizedException when WebSocket context has no user', async () => {
+      const mockExecutionContext = {
+        getHandler: jest.fn(),
+        getClass: jest.fn(),
+        getType: jest.fn().mockReturnValue('graphql'),
+        switchToHttp: jest.fn().mockReturnValue({ getRequest: () => ({}) }),
+      } as unknown as ExecutionContext;
+
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+      jest.spyOn(GqlExecutionContext, 'create').mockReturnValue({
+        getContext: jest.fn().mockReturnValue({
+          req: undefined,
+          res: undefined,
+          user: undefined,
+        }),
+      } as any);
+
+      await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
+        'WebSocket subscription: authentication required',
+      );
+      expect(Logger.prototype.warn).toHaveBeenCalledWith(
+        'WebSocket subscription rejected: no user in context',
+      );
+    });
+
+    it('should log and rethrow when parent guard throws', async () => {
+      const mockRequest = { user: null, headers: {} };
+      const mockExecutionContext = {
+        getHandler: jest.fn(),
+        getClass: jest.fn(),
+        getType: jest.fn().mockReturnValue('http'),
+        switchToHttp: jest.fn().mockReturnValue({ getRequest: () => mockRequest }),
+      } as unknown as ExecutionContext;
+
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+      const parentPrototype = Object.getPrototypeOf(GqlAuthGuard.prototype) as {
+        canActivate: (c: ExecutionContext) => Promise<boolean>;
+      };
+      jest.spyOn(parentPrototype, 'canActivate').mockRejectedValue(new Error('Invalid token'));
+
+      await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow('Invalid token');
+      expect(Logger.prototype.warn).toHaveBeenCalledWith(
+        'Authentication failed: Invalid token',
+      );
+    });
   });
 });

--- a/backend/src/modules/notifications/notifications-scheduler.service.spec.ts
+++ b/backend/src/modules/notifications/notifications-scheduler.service.spec.ts
@@ -1,0 +1,155 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationsSchedulerService } from './notifications-scheduler.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { NotificationsService } from './notifications.service';
+import { NotificationType } from '@prisma/client';
+
+describe('NotificationsSchedulerService', () => {
+  let service: NotificationsSchedulerService;
+  let prisma: PrismaService;
+  let notificationsService: NotificationsService;
+
+  const mockPrisma = {
+    card: {
+      findMany: jest.fn(),
+    },
+    notification: {
+      findFirst: jest.fn(),
+    },
+  };
+
+  const mockNotificationsService = {
+    create: jest.fn().mockResolvedValue({
+      id: 'notif-1',
+      userId: 'user-1',
+      type: NotificationType.CARD_DUE_SOON,
+      read: false,
+      createdAt: new Date(),
+    }),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationsSchedulerService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: NotificationsService, useValue: mockNotificationsService },
+      ],
+    }).compile();
+
+    service = module.get<NotificationsSchedulerService>(NotificationsSchedulerService);
+    prisma = module.get<PrismaService>(PrismaService);
+    notificationsService = module.get<NotificationsService>(NotificationsService);
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('sendCardDueSoonNotifications', () => {
+    it('should do nothing when no cards are due soon', async () => {
+      mockPrisma.card.findMany.mockResolvedValue([]);
+
+      await service.sendCardDueSoonNotifications();
+
+      expect(prisma.card.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            isArchived: false,
+            dueDate: expect.any(Object),
+          }),
+          include: { assignees: { select: { userId: true } }, list: { select: { boardId: true } } },
+        }),
+      );
+      expect(mockPrisma.notification.findFirst).not.toHaveBeenCalled();
+      expect(notificationsService.create).not.toHaveBeenCalled();
+    });
+
+    it('should create CARD_DUE_SOON for each assignee when not already notified', async () => {
+      const now = new Date();
+      const card = {
+        id: 'card-1',
+        assignees: [{ userId: 'user-1' }, { userId: 'user-2' }],
+        list: { boardId: 'board-1' },
+      };
+      mockPrisma.card.findMany.mockResolvedValue([card]);
+      mockPrisma.notification.findFirst.mockResolvedValue(null);
+
+      await service.sendCardDueSoonNotifications();
+
+      expect(mockPrisma.notification.findFirst).toHaveBeenCalledTimes(2);
+      expect(notificationsService.create).toHaveBeenCalledTimes(2);
+      expect(notificationsService.create).toHaveBeenNthCalledWith(1, {
+        userId: 'user-1',
+        type: NotificationType.CARD_DUE_SOON,
+        payload: expect.stringContaining('card-1'),
+      });
+      expect(notificationsService.create).toHaveBeenNthCalledWith(2, {
+        userId: 'user-2',
+        type: NotificationType.CARD_DUE_SOON,
+        payload: expect.stringContaining('card-1'),
+      });
+    });
+
+    it('should skip assignee when already notified in last 24h', async () => {
+      const card = {
+        id: 'card-1',
+        assignees: [{ userId: 'user-1' }],
+        list: { boardId: 'board-1' },
+      };
+      mockPrisma.card.findMany.mockResolvedValue([card]);
+      mockPrisma.notification.findFirst.mockResolvedValueOnce({ id: 'existing-notif' });
+
+      await service.sendCardDueSoonNotifications();
+
+      expect(notificationsService.create).not.toHaveBeenCalled();
+    });
+
+    it('should include boardId in payload when list has boardId', async () => {
+      const card = {
+        id: 'card-1',
+        assignees: [{ userId: 'user-1' }],
+        list: { boardId: 'board-1' },
+      };
+      mockPrisma.card.findMany.mockResolvedValue([card]);
+      mockPrisma.notification.findFirst.mockResolvedValue(null);
+
+      await service.sendCardDueSoonNotifications();
+
+      const payload = JSON.parse((notificationsService.create as jest.Mock).mock.calls[0][0].payload);
+      expect(payload.cardId).toBe('card-1');
+      expect(payload.boardId).toBe('board-1');
+    });
+
+    it('should handle card with no list (boardId undefined)', async () => {
+      const card = {
+        id: 'card-1',
+        assignees: [{ userId: 'user-1' }],
+        list: null,
+      };
+      mockPrisma.card.findMany.mockResolvedValue([card]);
+      mockPrisma.notification.findFirst.mockResolvedValue(null);
+
+      await service.sendCardDueSoonNotifications();
+
+      const payload = JSON.parse((notificationsService.create as jest.Mock).mock.calls[0][0].payload);
+      expect(payload.cardId).toBe('card-1');
+      expect(payload.boardId).toBeUndefined();
+    });
+
+    it('should not create notification for card with no assignees', async () => {
+      const card = {
+        id: 'card-1',
+        assignees: [],
+        list: { boardId: 'board-1' },
+      };
+      mockPrisma.card.findMany.mockResolvedValue([card]);
+
+      await service.sendCardDueSoonNotifications();
+
+      expect(mockPrisma.notification.findFirst).not.toHaveBeenCalled();
+      expect(notificationsService.create).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/modules/notifications/notifications.resolver.spec.ts
+++ b/backend/src/modules/notifications/notifications.resolver.spec.ts
@@ -11,6 +11,8 @@ describe('NotificationsResolver', () => {
     findForUser: jest.fn(),
     markAsRead: jest.fn(),
     markAllAsRead: jest.fn(),
+    getPreferences: jest.fn(),
+    updatePreferences: jest.fn(),
   };
 
   const mockUser = { id: 'user-1' };
@@ -105,6 +107,37 @@ describe('NotificationsResolver', () => {
 
       expect(result).toBe(5);
       expect(notificationsService.markAllAsRead).toHaveBeenCalledWith('user-1');
+    });
+  });
+
+  describe('myNotificationPreferences', () => {
+    it('should return current user notification preferences', async () => {
+      const prefs = {
+        emailFrequency: 'DAILY',
+        allowDesktopNotifications: true,
+      };
+      mockNotificationsService.getPreferences.mockResolvedValue(prefs);
+
+      const result = await resolver.myNotificationPreferences(mockUser);
+
+      expect(result).toEqual(prefs);
+      expect(notificationsService.getPreferences).toHaveBeenCalledWith('user-1');
+    });
+  });
+
+  describe('updateMyNotificationPreferences', () => {
+    it('should call service updatePreferences with user id and input', async () => {
+      const input = { emailFrequency: 'INSTANT' as const, allowDesktopNotifications: true };
+      const prefs = {
+        emailFrequency: 'INSTANT',
+        allowDesktopNotifications: true,
+      };
+      mockNotificationsService.updatePreferences.mockResolvedValue(prefs);
+
+      const result = await resolver.updateMyNotificationPreferences(input, mockUser);
+
+      expect(result).toEqual(prefs);
+      expect(notificationsService.updatePreferences).toHaveBeenCalledWith('user-1', input);
     });
   });
 });

--- a/backend/src/modules/notifications/notifications.service.spec.ts
+++ b/backend/src/modules/notifications/notifications.service.spec.ts
@@ -27,6 +27,11 @@ describe('NotificationsService', () => {
       update: jest.fn(),
       updateMany: jest.fn(),
     },
+    userNotificationPreferences: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      upsert: jest.fn(),
+    },
   };
 
   beforeEach(async () => {
@@ -234,6 +239,93 @@ describe('NotificationsService', () => {
       const result = await service.markAllAsRead('user-1');
 
       expect(result).toBe(0);
+    });
+  });
+
+  describe('getPreferences', () => {
+    it('should return existing preferences', async () => {
+      const prefs = {
+        userId: 'user-1',
+        emailFrequency: 'DAILY',
+        allowDesktopNotifications: true,
+      };
+      mockPrismaService.userNotificationPreferences.findUnique.mockResolvedValue(prefs);
+
+      const result = await service.getPreferences('user-1');
+
+      expect(result.emailFrequency).toBe('DAILY');
+      expect(result.allowDesktopNotifications).toBe(true);
+      expect(prismaService.userNotificationPreferences.findUnique).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+      });
+      expect(prismaService.userNotificationPreferences.create).not.toHaveBeenCalled();
+    });
+
+    it('should create default preferences when none exist', async () => {
+      mockPrismaService.userNotificationPreferences.findUnique.mockResolvedValue(null);
+      mockPrismaService.userNotificationPreferences.create.mockResolvedValue({
+        userId: 'user-1',
+        emailFrequency: 'PERIODICALLY',
+        allowDesktopNotifications: false,
+      });
+
+      const result = await service.getPreferences('user-1');
+
+      expect(result.emailFrequency).toBe('PERIODICALLY');
+      expect(result.allowDesktopNotifications).toBe(false);
+      expect(prismaService.userNotificationPreferences.create).toHaveBeenCalledWith({
+        data: { userId: 'user-1' },
+      });
+    });
+  });
+
+  describe('updatePreferences', () => {
+    it('should upsert and return updated preferences', async () => {
+      mockPrismaService.userNotificationPreferences.upsert.mockResolvedValue({
+        userId: 'user-1',
+        emailFrequency: 'INSTANT',
+        allowDesktopNotifications: true,
+      });
+
+      const result = await service.updatePreferences('user-1', {
+        emailFrequency: 'INSTANT',
+        allowDesktopNotifications: true,
+      });
+
+      expect(result.emailFrequency).toBe('INSTANT');
+      expect(result.allowDesktopNotifications).toBe(true);
+      expect(prismaService.userNotificationPreferences.upsert).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+        create: {
+          userId: 'user-1',
+          emailFrequency: 'INSTANT',
+          allowDesktopNotifications: true,
+        },
+        update: {
+          emailFrequency: 'INSTANT',
+          allowDesktopNotifications: true,
+        },
+      });
+    });
+
+    it('should use defaults when creating via upsert with partial input', async () => {
+      mockPrismaService.userNotificationPreferences.upsert.mockResolvedValue({
+        userId: 'user-1',
+        emailFrequency: 'PERIODICALLY',
+        allowDesktopNotifications: false,
+      });
+
+      await service.updatePreferences('user-1', {});
+
+      expect(prismaService.userNotificationPreferences.upsert).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+        create: {
+          userId: 'user-1',
+          emailFrequency: 'PERIODICALLY',
+          allowDesktopNotifications: false,
+        },
+        update: {},
+      });
     });
   });
 });


### PR DESCRIPTION
- Add notifications-scheduler.service.spec.ts (sendCardDueSoonNotifications)
- NotificationsService: getPreferences, updatePreferences tests; mock userNotificationPreferences
- HttpException filter: dev logging tests, extensions.response assertion
- NotificationsResolver: myNotificationPreferences, updateMyNotificationPreferences
- GqlAuthGuard: WebSocket no-user UnauthorizedException, auth failure rethrow, getRequest user from connection